### PR TITLE
fix: guard missing page template

### DIFF
--- a/src/lib/addComponent.ts
+++ b/src/lib/addComponent.ts
@@ -2,7 +2,7 @@ import { join } from "node:path";
 import { mkdir, readFile, writeFile, readdir } from "node:fs/promises";
 import prompts from "prompts";
 import { capitalize } from "./utils"; // Assuming you have a utility function to capitalize strings
-import { existsSync } from "node:fs";
+import { existsSync, statSync } from "node:fs";
 
 export async function addComponent(args: string[]) {
   let componentName = args[1];
@@ -90,10 +90,7 @@ export async function addComponent(args: string[]) {
   for (const locale of langDirs) {
     // Only process if messages/<locale> is a directory
     const localeDir = join(messagesPath, locale);
-    if (
-      !existsSync(localeDir) ||
-      !require("node:fs").statSync(localeDir).isDirectory()
-    )
+    if (!existsSync(localeDir) || !statSync(localeDir).isDirectory())
       continue;
     let jsonTarget;
     if (pageScope) {

--- a/src/lib/addPage.ts
+++ b/src/lib/addPage.ts
@@ -2,7 +2,7 @@ import { join } from "node:path";
 import { mkdir, readFile, writeFile, readdir } from "node:fs/promises";
 import prompts from "prompts";
 import { capitalize, toFileName } from "./utils"; // Assuming you have a utility function to capitalize strings
-import { existsSync } from "node:fs";
+import { existsSync, statSync } from "node:fs";
 
 export async function addPage(args: string[]) {
   let pageName = args[1];
@@ -134,6 +134,7 @@ export async function addPage(args: string[]) {
   const jsonTemplate = join(templatePath, "page.json");
   if (!existsSync(jsonTemplate)) {
     console.warn("⚠️ Missing template page.json.");
+    return;
   }
   const content = await readFile(jsonTemplate, "utf-8");
   const replaced = content
@@ -142,10 +143,7 @@ export async function addPage(args: string[]) {
   for (const locale of locales) {
     // Only process if messages/<locale> is a directory
     const localeDir = join(messagesPath, locale);
-    if (
-      !existsSync(localeDir) ||
-      !require("node:fs").statSync(localeDir).isDirectory()
-    )
+    if (!existsSync(localeDir) || !statSync(localeDir).isDirectory())
       continue;
     const jsonTarget = join(messagesPath, locale, `${jsonFileName}.json`);
     let current: Record<string, any> = {};


### PR DESCRIPTION
## Summary
- avoid crash when Page template is missing
- use `statSync` instead of CommonJS `require` in page/component utilities

## Testing
- `npm test` (fails: Missing script)
- `bun test`

------
https://chatgpt.com/codex/tasks/task_e_68a8d3d1512083239b6baecb80027792