### PR TITLE
chore: add CI workflow and scripts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,31 @@
+name: CI
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+
+jobs:
+  test-build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: oven-sh/setup-bun@v1
+      - run: bun install
+      - run: bun test
+      - run: bun run build
+
+  publish:
+    needs: test-build
+    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+    runs-on: ubuntu-latest
+    environment:
+      name: NMP_TOKEN
+    env:
+      NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: oven-sh/setup-bun@v1
+      - run: bun install
+      - run: bun run build
+      - run: bun publish

--- a/package.json
+++ b/package.json
@@ -16,6 +16,9 @@
     "dev": "bun run bin.ts",
     "scaffold-dev": "bun run src/scaffold-dev.ts",
     "postinstall": "bash install.sh",
+    "test": "bun test",
+    "build": "bun build bin.ts --outdir dist --target bun",
+    "prepublishOnly": "bun run build",
     "commit": "cz",
     "release": "bunx --bun standard-version",
     "prepare-husky": "husky"

--- a/src/lib/utils.test.ts
+++ b/src/lib/utils.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, test } from "bun:test";
+import { toFileName } from "./utils";
+
+describe("toFileName", () => {
+  const cases: [string, string][] = [
+    ["layout", "layout.tsx"],
+    ["page", "page.tsx"],
+    ["loading", "loading.tsx"],
+    ["not-found", "not-found.tsx"],
+    ["error", "error.tsx"],
+    ["global-error", "global-error.tsx"],
+    ["route", "route.ts"],
+    ["template", "template.tsx"],
+    ["default", "default.tsx"],
+    ["foo", "foo.tsx"],
+  ];
+
+  for (const [key, expected] of cases) {
+    test(`maps "${key}" to "${expected}"`, () => {
+      expect(toFileName(key)).toBe(expected);
+    });
+  }
+});


### PR DESCRIPTION
## Summary
- add test, build, and prepublish scripts
- add GitHub Actions workflow to test, build, and publish using NPM_TOKEN

## Testing
- `bun test`
- `bun run build`


