### PR TITLE
feat: extend CLI with translation helpers

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -14,6 +14,8 @@ import { addLib } from "./lib/addLib";
 import { addApi } from "./lib/addApi";
 import { createProject } from "./lib/createProject";
 import { createProjectWithPrompt } from "./lib/createProjectWithPrompt";
+import { addLanguage } from "./lib/addLanguage";
+import { addText } from "./lib/addText";
 
 type Cfg = {
   version: 1;
@@ -125,6 +127,8 @@ Usage:
   create-next-pro addcomponent [options]
   create-next-pro addlib [name]
   create-next-pro addapi [name]
+  create-next-pro addlanguage [locale]
+  create-next-pro addtext <path> [text]
   create-next-pro rmpage [options]
 
 Options:
@@ -200,6 +204,16 @@ export async function main() {
    */
   if (args[0] === "addapi") {
     addApi(args);
+    return;
+  }
+
+  if (args[0] === "addlanguage") {
+    await addLanguage(args);
+    return;
+  }
+
+  if (args[0] === "addtext") {
+    await addText(args);
     return;
   }
 

--- a/src/lib/addComponent.ts
+++ b/src/lib/addComponent.ts
@@ -124,6 +124,7 @@ export async function addComponent(args: string[]) {
       }
       current[componentNameUpper] = parsed;
       await writeFile(jsonTarget, JSON.stringify(current, null, 2));
+      console.log(`📄 File updated: ${jsonTarget}`);
     }
   } else {
     console.log("ℹ️ Skipping translation entries; next-intl not enabled.");

--- a/src/lib/addLanguage.ts
+++ b/src/lib/addLanguage.ts
@@ -1,0 +1,90 @@
+import { join } from "node:path";
+import { existsSync } from "node:fs";
+import { cp, readFile, writeFile } from "node:fs/promises";
+import prompts from "prompts";
+
+import { loadConfig } from "./utils";
+
+function generateLocales(): string[] {
+  const dn = new Intl.DisplayNames(["en"], { type: "language" });
+  const locales: string[] = [];
+  for (let i = 0; i < 26; i++) {
+    for (let j = 0; j < 26; j++) {
+      const code = String.fromCharCode(97 + i) + String.fromCharCode(97 + j);
+      try {
+        const name = dn.of(code);
+        if (name && name.toLowerCase() !== code) {
+          locales.push(code);
+        }
+      } catch {}
+    }
+  }
+  return locales.sort();
+}
+
+export async function addLanguage(args: string[]) {
+  const config = await loadConfig();
+  if (!config?.useI18n) {
+    console.error("❌ i18n is not enabled in this project.");
+    return;
+  }
+  const messagesPath = join(process.cwd(), "messages");
+  if (!existsSync(messagesPath)) {
+    console.error("❌ Messages directory missing. Ensure i18n was configured.");
+    return;
+  }
+
+  const available = generateLocales();
+  let locale = args[1];
+  if (!locale || !available.includes(locale)) {
+    const response = await prompts({
+      type: "autocomplete",
+      name: "locale",
+      message: "🌐 Locale to add:",
+      choices: available.map((l) => ({ title: l, value: l })),
+    });
+    locale = response.locale;
+  }
+  if (!locale) return;
+  if (existsSync(join(messagesPath, locale))) {
+    console.error(`❌ Locale ${locale} already exists.`);
+    return;
+  }
+
+  const routingFile = join(process.cwd(), "src", "lib", "i18n", "routing.ts");
+  if (!existsSync(routingFile)) {
+    console.error("❌ routing.ts not found. Are you in project root?");
+    return;
+  }
+  const routingContent = await readFile(routingFile, "utf-8");
+  const defaultMatch = routingContent.match(/defaultLocale:\s*"([^"]+)"/);
+  const defaultLocale = defaultMatch ? defaultMatch[1] : null;
+  if (!defaultLocale || !existsSync(join(messagesPath, defaultLocale))) {
+    console.error("❌ Default locale not found.");
+    return;
+  }
+
+  await cp(join(messagesPath, defaultLocale), join(messagesPath, locale), {
+    recursive: true,
+  });
+  console.log(`📄 Directory created: ${join(messagesPath, locale)}`);
+
+  const localesMatch = routingContent.match(/locales:\s*\[([^\]]*)\]/);
+  if (localesMatch) {
+    const localesArr = localesMatch[1]
+      .split(",")
+      .map((s) => s.trim().replace(/["']/g, ""))
+      .filter(Boolean);
+    if (!localesArr.includes(locale)) {
+      localesArr.push(locale);
+      const newLocales = `locales: [${localesArr.map((l) => `"${l}"`).join(", " )}]`;
+      const newContent = routingContent.replace(/locales:\s*\[[^\]]*\]/, newLocales);
+      await writeFile(routingFile, newContent);
+      console.log(`📄 File updated: ${routingFile}`);
+    }
+  }
+
+  console.log(
+    `✅ Locale "${locale}" added and copied from default locale "${defaultLocale}".`,
+  );
+}

--- a/src/lib/addPage.ts
+++ b/src/lib/addPage.ts
@@ -197,6 +197,7 @@ export async function addPage(args: string[]) {
           current = JSON.parse(replaced);
         }
         await writeFile(jsonTarget, JSON.stringify(current, null, 2));
+        console.log(`📄 File created: ${jsonTarget}`);
       }
     }
   } else {

--- a/src/lib/addText.ts
+++ b/src/lib/addText.ts
@@ -1,0 +1,64 @@
+import { join } from "node:path";
+import { existsSync } from "node:fs";
+import { readFile, writeFile, readdir } from "node:fs/promises";
+
+import { loadConfig } from "./utils";
+
+function defaultText(key: string) {
+  return key
+    .replace(/_/g, " ")
+    .replace(/\b\w/g, (c) => c.toUpperCase());
+}
+
+export async function addText(args: string[]) {
+  const pathArg = args[1];
+  if (!pathArg) {
+    console.error("❌ Dot path parameter is required.");
+    return;
+  }
+  const providedText = args.slice(2).join(" ");
+
+  const config = await loadConfig();
+  if (!config?.useI18n) {
+    console.error("❌ i18n is not enabled in this project.");
+    return;
+  }
+  const messagesPath = join(process.cwd(), "messages");
+  if (!existsSync(messagesPath)) {
+    console.error("❌ Messages directory missing. Ensure i18n was configured.");
+    return;
+  }
+
+  const entries = await readdir(messagesPath, { withFileTypes: true });
+  const locales = entries.filter((e) => e.isDirectory()).map((e) => e.name);
+
+  const [fileName, ...segments] = pathArg.split(".");
+  if (!fileName || segments.length === 0) {
+    console.error("❌ Invalid dot path provided.");
+    return;
+  }
+  const finalKey = segments[segments.length - 1];
+  const text = providedText || defaultText(finalKey);
+
+  for (const locale of locales) {
+    const filePath = join(messagesPath, locale, `${fileName}.json`);
+    let data: Record<string, any> = {};
+    if (existsSync(filePath)) {
+      const raw = await readFile(filePath, "utf-8");
+      try {
+        data = JSON.parse(raw) as Record<string, any>;
+      } catch {}
+    }
+    let cursor = data;
+    for (let i = 0; i < segments.length - 1; i++) {
+      const seg = segments[i];
+      if (!cursor[seg]) cursor[seg] = {};
+      cursor = cursor[seg];
+    }
+    cursor[finalKey] = text;
+    await writeFile(filePath, JSON.stringify(data, null, 2));
+    console.log(`📄 File updated: ${filePath}`);
+  }
+
+  console.log(`✅ Text added at path "${pathArg}" with value "${text}".`);
+}


### PR DESCRIPTION
## Summary
- log translation JSON paths when creating components/pages
- add `addlanguage` command to scaffold a new locale from default
- add `addtext` command to insert translation keys by dot path
- document new commands in CLI help

## Testing
- `npm test`
