### PR TITLE
fix(governance): restrict external workflow execution

### DIFF
--- a/.github/governance/policy.json
+++ b/.github/governance/policy.json
@@ -18,7 +18,8 @@
     "allowedActions": "selected",
     "shaPinningRequired": true,
     "defaultWorkflowPermissions": "read",
-    "canApprovePullRequestReviews": false
+    "canApprovePullRequestReviews": false,
+    "forkPullRequestApprovalPolicy": "all_external_contributors"
   },
   "environment": {
     "name": "ENV",

--- a/.github/governance/policy.json
+++ b/.github/governance/policy.json
@@ -62,7 +62,9 @@
   },
   "rulesets": {
     "branch": "protect-master",
-    "tag": "protect-release-tags"
+    "contributions": "govern-master-contributions",
+    "tag": "protect-release-tags",
+    "allowAdminDirectPush": true
   },
   "requiredChecks": [
     "validate-cli",

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,8 +1,8 @@
 # Contributing to create-next-pro-cli
 
-Thank you for improving `create-next-pro-cli`. Contributions use a trunk-based workflow: `master` is the single source of truth and every human change reaches it through a pull request.
+Thank you for improving `create-next-pro-cli`. Contributions use a trunk-based workflow with `master` as the single source of truth. External contributors and non-admin maintainers use pull requests. Repository administrators may also push directly to `master` when an immediate maintained change is appropriate.
 
-Public visibility does not grant write access. External contributors propose changes from a fork. Only repository administrators and explicitly authorized maintainers may push branches to the canonical repository or merge pull requests. Contributors must never push directly to `master`.
+Public visibility does not grant write access. External contributors propose changes from a fork. Explicitly authorized maintainers may push short-lived branches to the canonical repository and open pull requests. Only repository administrators may push directly to `master`; pull request merges remain restricted to repository administrators and explicitly authorized maintainers.
 
 ## Requirements
 
@@ -22,7 +22,7 @@ git switch -c fix/describe-the-change upstream/master
 git push --set-upstream origin fix/describe-the-change
 ```
 
-Use `feat/*`, `fix/*`, `docs/*`, `chore/*`, or `ci/*` as appropriate. An authorized maintainer may create the same short-lived branch directly in the canonical repository, but must still use a pull request. The historical `dev` branch is not part of the contribution flow.
+Use `feat/*`, `fix/*`, `docs/*`, `chore/*`, or `ci/*` as appropriate. An authorized non-admin maintainer may create the same short-lived branch directly in the canonical repository, but must still use a pull request. The historical `dev` branch is not part of the contribution flow.
 
 Commits and pull request titles must follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/), for example:
 
@@ -67,9 +67,9 @@ Do not weaken an audit, remove a consumer, or update a snapshot merely to make a
 
 Open pull requests against `master`. Complete the template, link relevant issues, describe public behavior changes, and list the exact checks executed. All required checks and conversations must be resolved before merging. Only repository administrators and explicitly authorized maintainers may perform the squash merge.
 
-Pull request workflows are read-only and cannot publish a package or update `master`. Workflows from first-time forks may require maintainer approval before they run. Maintainers review the workflow diff before approving it.
+Pull request workflows are read-only and cannot publish a package or update `master`. Workflows from every external fork require maintainer approval before they run. Maintainers review the workflow diff before approving it.
 
-Do not publish npm packages, create release tags, or edit versions manually. Only the resulting authorized merge to `master` is eligible to trigger the protected patch release workflow, when release automation is enabled.
+Do not publish npm packages, create release tags, or edit versions manually. An authorized merge or direct administrator push to `master` is eligible to trigger the protected patch release workflow when release automation is enabled.
 
 ## Security and sensitive data
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,8 @@
 
 Thank you for improving `create-next-pro-cli`. Contributions use a trunk-based workflow: `master` is the single source of truth and every human change reaches it through a pull request.
 
+Public visibility does not grant write access. External contributors propose changes from a fork. Only repository administrators and explicitly authorized maintainers may push branches to the canonical repository or merge pull requests. Contributors must never push directly to `master`.
+
 ## Requirements
 
 - Bun 1.3.14 for the locked repository installation and root checks.
@@ -11,16 +13,16 @@ Thank you for improving `create-next-pro-cli`. Contributions use a trunk-based w
 
 ## Branches and commits
 
-Create a short-lived branch from the latest `master`:
+Fork the repository, then create a short-lived branch from the latest upstream `master`:
 
 ```bash
-git fetch origin
-git switch master
-git pull --ff-only origin master
-git switch -c fix/describe-the-change
+git remote add upstream https://github.com/Rising-Corporation/create-next-pro-cli.git
+git fetch upstream
+git switch -c fix/describe-the-change upstream/master
+git push --set-upstream origin fix/describe-the-change
 ```
 
-Use `feature/*`, `fix/*`, `docs/*`, or `chore/*` as appropriate. The historical `dev` branch is not part of the contribution flow.
+Use `feat/*`, `fix/*`, `docs/*`, `chore/*`, or `ci/*` as appropriate. An authorized maintainer may create the same short-lived branch directly in the canonical repository, but must still use a pull request. The historical `dev` branch is not part of the contribution flow.
 
 Commits and pull request titles must follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/), for example:
 
@@ -59,15 +61,15 @@ bun run test:e2e
 bun run audit
 ```
 
-Do not weaken an audit, remove a consumer, or update a snapshot merely to make a check pass. Document a repeated blocker in `.agent/TROUBLESHOOTING.md` without including secrets.
+Do not weaken an audit, remove a consumer, or update a snapshot merely to make a check pass. If a check fails repeatedly, describe the failure, reproduction steps, and redacted logs in the pull request without including secrets.
 
 ## Pull requests
 
-Open pull requests against `master`. Complete the template, link relevant issues, describe public behavior changes, and list the exact checks executed. All required checks and conversations must be resolved before merging.
+Open pull requests against `master`. Complete the template, link relevant issues, describe public behavior changes, and list the exact checks executed. All required checks and conversations must be resolved before merging. Only repository administrators and explicitly authorized maintainers may perform the squash merge.
 
-Workflows from first-time forks may require maintainer approval before they run. Maintainers review the workflow diff before approving it.
+Pull request workflows are read-only and cannot publish a package or update `master`. Workflows from first-time forks may require maintainer approval before they run. Maintainers review the workflow diff before approving it.
 
-Do not publish npm packages, create release tags, or edit versions manually. A validated merge to `master` triggers the protected patch release workflow.
+Do not publish npm packages, create release tags, or edit versions manually. Only the resulting authorized merge to `master` is eligible to trigger the protected patch release workflow, when release automation is enabled.
 
 ## Security and sensitive data
 

--- a/scripts/github-governance.ts
+++ b/scripts/github-governance.ts
@@ -134,6 +134,13 @@ function applyRepositorySettings(policy: GovernancePolicy): void {
     default_workflow_permissions: "read",
     can_approve_pull_request_reviews: false,
   });
+  mutate(
+    "PUT",
+    `repos/${policy.repository}/actions/permissions/fork-pr-contributor-approval`,
+    {
+      approval_policy: policy.actions.forkPullRequestApprovalPolicy,
+    },
+  );
 }
 
 function applySecurity(policy: GovernancePolicy): void {

--- a/scripts/github-governance.ts
+++ b/scripts/github-governance.ts
@@ -13,7 +13,8 @@ import {
   type GovernanceResult,
 } from "../src/governance/model";
 import {
-  buildBranchRuleset,
+  buildBranchContributionRuleset,
+  buildBranchSafetyRuleset,
   buildTagRuleset,
   type RepositoryRuleset,
   type RulesetStage,
@@ -244,17 +245,21 @@ function applyRulesets(policy: GovernancePolicy, stage: RulesetStage): void {
     (variable) => variable.name === policy.release.appIdVariable,
   )?.value;
   const appId = rawAppId ? Number(rawAppId) : undefined;
-  if (
-    stage === "full" &&
-    (!appId || !Number.isSafeInteger(appId) || appId <= 0)
-  ) {
+  if (appId !== undefined && (!Number.isSafeInteger(appId) || appId <= 0)) {
     throw new Error(
-      `${policy.release.appIdVariable} must identify the installed release App before rulesets are applied`,
+      `${policy.release.appIdVariable} must identify a valid installed release App`,
     );
   }
-  upsertRuleset(policy, buildBranchRuleset(policy, appId, stage));
+  upsertRuleset(policy, buildBranchSafetyRuleset(policy));
+  if (stage === "branch" || stage === "full") {
+    upsertRuleset(policy, buildBranchContributionRuleset(policy, appId));
+  }
   if (stage === "full") {
-    if (!appId) throw new Error("Full rulesets require the release App ID");
+    if (!appId) {
+      throw new Error(
+        `Full rulesets require ${policy.release.appIdVariable} for release tags`,
+      );
+    }
     upsertRuleset(policy, buildTagRuleset(policy, appId));
   }
 }
@@ -325,10 +330,15 @@ async function main(): Promise<void> {
     applyLabels(policy);
     applyEnvironment(policy);
     const stage = argumentValue("--stage") ?? "settings";
-    if (stage !== "settings" && stage !== "minimal" && stage !== "full") {
-      throw new Error("--stage must be settings, minimal, or full");
+    if (
+      stage !== "settings" &&
+      stage !== "minimal" &&
+      stage !== "branch" &&
+      stage !== "full"
+    ) {
+      throw new Error("--stage must be settings, minimal, branch, or full");
     }
-    if (stage === "minimal" || stage === "full") {
+    if (stage === "minimal" || stage === "branch" || stage === "full") {
       applyRulesets(policy, stage);
     }
     if (hasArgument("--include-cleanup")) applyCleanup(policy);

--- a/src/governance/contracts.test.ts
+++ b/src/governance/contracts.test.ts
@@ -42,6 +42,20 @@ describe("public governance contracts", () => {
     );
   });
 
+  test("documents a restricted public contribution workflow", async () => {
+    const contributing = await readFile("CONTRIBUTING.md", "utf8");
+    expect(contributing).toContain(
+      "Public visibility does not grant write access.",
+    );
+    expect(contributing).toContain(
+      "Only repository administrators and explicitly authorized maintainers may perform the squash merge.",
+    );
+    expect(contributing).toContain(
+      "Pull request workflows are read-only and cannot publish a package or update `master`.",
+    );
+    expect(contributing).not.toContain(".agent/");
+  });
+
   test("keeps functionality documentation aligned with public operations", async () => {
     const functionality = await readFile("FUNCTIONALITY.md", "utf8");
     expect(functionality).toContain("create-next-pro <project>");

--- a/src/governance/contracts.test.ts
+++ b/src/governance/contracts.test.ts
@@ -48,7 +48,10 @@ describe("public governance contracts", () => {
       "Public visibility does not grant write access.",
     );
     expect(contributing).toContain(
-      "Only repository administrators and explicitly authorized maintainers may perform the squash merge.",
+      "Only repository administrators may push directly to `master`",
+    );
+    expect(contributing).toContain(
+      "Workflows from every external fork require maintainer approval",
     );
     expect(contributing).toContain(
       "Pull request workflows are read-only and cannot publish a package or update `master`.",

--- a/src/governance/github.test.ts
+++ b/src/governance/github.test.ts
@@ -18,7 +18,12 @@ const policy = {
     forbiddenSecrets: [],
     releaseEnabled: true,
   },
-  rulesets: { branch: "protect-master", tag: "protect-tags" },
+  rulesets: {
+    branch: "protect-master",
+    contributions: "govern-master-contributions",
+    tag: "protect-tags",
+    allowAdminDirectPush: true,
+  },
   requiredChecks: [],
   cleanup: { pullRequests: [], branches: [] },
   projectsPolicy: "disable-if-empty",

--- a/src/governance/github.test.ts
+++ b/src/governance/github.test.ts
@@ -50,6 +50,9 @@ describe("GitHub governance adapter", () => {
         if (endpoint.endsWith("/actions/variables?per_page=100")) {
           return { variables: [{ name: "RELEASE_ENABLED", value: "true" }] };
         }
+        if (endpoint.endsWith("/fork-pr-contributor-approval")) {
+          return { approval_policy: "all_external_contributors" };
+        }
         if (endpoint.includes("/installations")) {
           return { installations: [{ app_slug: "release-app" }] };
         }
@@ -73,12 +76,18 @@ describe("GitHub governance adapter", () => {
     expect(snapshot.release.secretNames).toEqual(["APP_KEY"]);
     expect(snapshot.release.variableNames).toEqual(["APP_ID"]);
     expect(snapshot.release.releaseEnabled).toBe(true);
+    expect(snapshot.actions.forkPullRequestApprovalPolicy).toBe(
+      "all_external_contributors",
+    );
     expect(JSON.stringify(snapshot)).not.toContain("must-not-be-read");
     expect(requested).toContain(
       "repos/owner/repository/environments/ENV/secrets?per_page=100",
     );
     expect(requested).toContain(
       "repos/owner/repository/environments/ENV/variables?per_page=100",
+    );
+    expect(requested).toContain(
+      "repos/owner/repository/actions/permissions/fork-pr-contributor-approval",
     );
   });
 

--- a/src/governance/github.ts
+++ b/src/governance/github.ts
@@ -63,6 +63,13 @@ export async function collectGithubSnapshot(
       ),
     ),
   );
+  const forkApproval = record(
+    await optional(unavailable, "actions.forkPullRequestApprovalPolicy", () =>
+      transport.request(
+        `repos/${policy.repository}/actions/permissions/fork-pr-contributor-approval`,
+      ),
+    ),
+  );
   const environment = record(
     await optional(unavailable, "environment", () =>
       transport.request(
@@ -200,6 +207,13 @@ export async function collectGithubSnapshot(
       canApprovePullRequestReviews: boolean(
         workflow.can_approve_pull_request_reviews,
       ),
+      forkPullRequestApprovalPolicy:
+        string(forkApproval.approval_policy) === "all_external_contributors"
+          ? "all_external_contributors"
+          : string(forkApproval.approval_policy) ===
+              "first_time_contributors_new_to_github"
+            ? "first_time_contributors_new_to_github"
+            : "first_time_contributors",
     },
     environment: {
       exists: Boolean(environment.name),

--- a/src/governance/model.test.ts
+++ b/src/governance/model.test.ts
@@ -28,6 +28,7 @@ const policy: GovernancePolicy = {
     shaPinningRequired: true,
     defaultWorkflowPermissions: "read",
     canApprovePullRequestReviews: false,
+    forkPullRequestApprovalPolicy: "all_external_contributors",
   },
   environment: { name: "ENV", branch: "master" },
   security: {

--- a/src/governance/model.test.ts
+++ b/src/governance/model.test.ts
@@ -49,7 +49,12 @@ const policy: GovernancePolicy = {
     forbiddenSecrets: ["OLD_TOKEN"],
     releaseEnabled: true,
   },
-  rulesets: { branch: "protect-master", tag: "protect-tags" },
+  rulesets: {
+    branch: "protect-master",
+    contributions: "govern-master-contributions",
+    tag: "protect-tags",
+    allowAdminDirectPush: true,
+  },
   requiredChecks: ["validate"],
   cleanup: { pullRequests: [], branches: [] },
   projectsPolicy: "disable-if-empty",
@@ -74,6 +79,7 @@ const snapshot: GovernanceSnapshot = {
   },
   rulesets: [
     { name: "protect-master", enforcement: "active" },
+    { name: "govern-master-contributions", enforcement: "active" },
     { name: "protect-tags", enforcement: "active" },
   ],
   projects: { totalCount: 1 },

--- a/src/governance/model.ts
+++ b/src/governance/model.ts
@@ -54,7 +54,12 @@ export type GovernancePolicy = {
     forbiddenSecrets: string[];
     releaseEnabled: boolean;
   };
-  rulesets: { branch: string; tag: string };
+  rulesets: {
+    branch: string;
+    contributions: string;
+    tag: string;
+    allowAdminDirectPush: boolean;
+  };
   requiredChecks: string[];
   cleanup: {
     pullRequests: number[];
@@ -249,7 +254,11 @@ export function compareGovernance(
   containsAll(
     findings,
     "rulesets",
-    [policy.rulesets.branch, policy.rulesets.tag],
+    [
+      policy.rulesets.branch,
+      policy.rulesets.contributions,
+      policy.rulesets.tag,
+    ],
     snapshot.rulesets
       .filter((ruleset) => ruleset.enforcement === "active")
       .map((ruleset) => ruleset.name),

--- a/src/governance/model.ts
+++ b/src/governance/model.ts
@@ -30,6 +30,10 @@ export type GovernancePolicy = {
     shaPinningRequired: boolean;
     defaultWorkflowPermissions: "read" | "write";
     canApprovePullRequestReviews: boolean;
+    forkPullRequestApprovalPolicy:
+      | "first_time_contributors"
+      | "first_time_contributors_new_to_github"
+      | "all_external_contributors";
   };
   environment: { name: string; branch: string };
   security: {

--- a/src/governance/rulesets.test.ts
+++ b/src/governance/rulesets.test.ts
@@ -1,17 +1,26 @@
 import { describe, expect, test } from "vitest";
 
 import type { GovernancePolicy } from "./model";
-import { buildBranchRuleset, buildTagRuleset } from "./rulesets";
+import {
+  buildBranchContributionRuleset,
+  buildBranchSafetyRuleset,
+  buildTagRuleset,
+} from "./rulesets";
 
 const policy = {
-  rulesets: { branch: "protect-master", tag: "protect-release-tags" },
+  rulesets: {
+    branch: "protect-master",
+    contributions: "govern-master-contributions",
+    tag: "protect-release-tags",
+    allowAdminDirectPush: true,
+  },
   requiredChecks: ["validate-cli", "validate-template (bun)"],
   cleanup: { pullRequests: [], branches: [] },
 } as unknown as GovernancePolicy;
 
 describe("governance rulesets", () => {
-  test("builds a reversible minimal branch protection", () => {
-    const ruleset = buildBranchRuleset(policy, undefined, "minimal");
+  test("keeps destructive protections separate without bypass", () => {
+    const ruleset = buildBranchSafetyRuleset(policy);
     expect(ruleset.conditions.ref_name.include).toEqual(["~DEFAULT_BRANCH"]);
     expect(ruleset.rules.map((rule) => rule.type)).toEqual([
       "deletion",
@@ -20,14 +29,42 @@ describe("governance rulesets", () => {
     expect(ruleset.bypass_actors).toEqual([]);
   });
 
+  test("allows repository admins to bypass only contribution gates", () => {
+    const ruleset = buildBranchContributionRuleset(policy);
+    expect(ruleset.name).toBe("govern-master-contributions");
+    expect(ruleset.bypass_actors).toEqual([
+      {
+        actor_id: 5,
+        actor_type: "RepositoryRole",
+        bypass_mode: "always",
+      },
+    ]);
+    expect(ruleset.rules.map((rule) => rule.type)).not.toContain("deletion");
+    expect(ruleset.rules.map((rule) => rule.type)).not.toContain(
+      "non_fast_forward",
+    );
+  });
+
   test("requires pull requests and exact GitHub Actions checks", () => {
-    const ruleset = buildBranchRuleset(policy, 123, "full");
+    const ruleset = buildBranchContributionRuleset(policy, 123);
     const checks = ruleset.rules.find(
       (rule) => rule.type === "required_status_checks",
     );
     expect(checks?.parameters?.required_status_checks).toEqual([
       { context: "validate-cli", integration_id: 15368 },
       { context: "validate-template (bun)", integration_id: 15368 },
+    ]);
+    expect(ruleset.bypass_actors).toEqual([
+      {
+        actor_id: 5,
+        actor_type: "RepositoryRole",
+        bypass_mode: "always",
+      },
+      {
+        actor_id: 123,
+        actor_type: "Integration",
+        bypass_mode: "always",
+      },
     ]);
     expect(ruleset.rules).toContainEqual({
       type: "code_scanning",
@@ -46,6 +83,13 @@ describe("governance rulesets", () => {
   test("reserves v-prefixed tags for the release App", () => {
     const ruleset = buildTagRuleset(policy, 123);
     expect(ruleset.conditions.ref_name.include).toEqual(["refs/tags/v*"]);
+    expect(ruleset.bypass_actors).toEqual([
+      {
+        actor_id: 123,
+        actor_type: "Integration",
+        bypass_mode: "always",
+      },
+    ]);
     expect(ruleset.rules.map((rule) => rule.type)).toEqual([
       "creation",
       "update",
@@ -55,14 +99,9 @@ describe("governance rulesets", () => {
   });
 
   test("rejects invalid App identifiers", () => {
-    expect(() => buildBranchRuleset(policy, 0, "full")).toThrow(
+    expect(() => buildBranchContributionRuleset(policy, 0)).toThrow(
       "positive integer",
     );
-  });
-
-  test("refuses full protection without the dedicated release App", () => {
-    expect(() => buildBranchRuleset(policy, undefined, "full")).toThrow(
-      "requires the release App ID",
-    );
+    expect(() => buildTagRuleset(policy, 0)).toThrow("positive integer");
   });
 });

--- a/src/governance/rulesets.ts
+++ b/src/governance/rulesets.ts
@@ -1,6 +1,6 @@
 import type { GovernancePolicy } from "./model";
 
-export type RulesetStage = "minimal" | "full";
+export type RulesetStage = "minimal" | "branch" | "full";
 
 type RulesetRule = {
   type: string;
@@ -13,7 +13,7 @@ export type RepositoryRuleset = {
   enforcement: "active";
   bypass_actors: Array<{
     actor_id: number;
-    actor_type: "Integration";
+    actor_type: "Integration" | "RepositoryRole";
     bypass_mode: "always";
   }>;
   conditions: {
@@ -22,7 +22,9 @@ export type RepositoryRuleset = {
   rules: RulesetRule[];
 };
 
-function bypass(appId: number): RepositoryRuleset["bypass_actors"] {
+const REPOSITORY_ADMIN_ROLE_ID = 5;
+
+function releaseAppBypass(appId: number): RepositoryRuleset["bypass_actors"] {
   if (!Number.isSafeInteger(appId) || appId <= 0) {
     throw new Error("Release App ID must be a positive integer");
   }
@@ -35,20 +37,48 @@ function bypass(appId: number): RepositoryRuleset["bypass_actors"] {
   ];
 }
 
-export function buildBranchRuleset(
-  policy: GovernancePolicy,
-  appId: number | undefined,
-  stage: RulesetStage,
-): RepositoryRuleset {
-  if (stage === "full" && appId === undefined) {
-    throw new Error("Full branch protection requires the release App ID");
-  }
-  const rules: RulesetRule[] = [
-    { type: "deletion" },
-    { type: "non_fast_forward" },
+function adminBypass(): RepositoryRuleset["bypass_actors"] {
+  return [
+    {
+      actor_id: REPOSITORY_ADMIN_ROLE_ID,
+      actor_type: "RepositoryRole",
+      bypass_mode: "always",
+    },
   ];
-  if (stage === "full") {
-    rules.push(
+}
+
+export function buildBranchSafetyRuleset(
+  policy: GovernancePolicy,
+): RepositoryRuleset {
+  return {
+    name: policy.rulesets.branch,
+    target: "branch",
+    enforcement: "active",
+    bypass_actors: [],
+    conditions: {
+      ref_name: { include: ["~DEFAULT_BRANCH"], exclude: [] },
+    },
+    rules: [{ type: "deletion" }, { type: "non_fast_forward" }],
+  };
+}
+
+export function buildBranchContributionRuleset(
+  policy: GovernancePolicy,
+  appId?: number,
+): RepositoryRuleset {
+  const bypassActors = policy.rulesets.allowAdminDirectPush
+    ? adminBypass()
+    : [];
+  if (appId !== undefined) bypassActors.push(...releaseAppBypass(appId));
+  return {
+    name: policy.rulesets.contributions,
+    target: "branch",
+    enforcement: "active",
+    bypass_actors: bypassActors,
+    conditions: {
+      ref_name: { include: ["~DEFAULT_BRANCH"], exclude: [] },
+    },
+    rules: [
       {
         type: "pull_request",
         parameters: {
@@ -82,17 +112,7 @@ export function buildBranchRuleset(
           ],
         },
       },
-    );
-  }
-  return {
-    name: policy.rulesets.branch,
-    target: "branch",
-    enforcement: "active",
-    bypass_actors: appId === undefined ? [] : bypass(appId),
-    conditions: {
-      ref_name: { include: ["~DEFAULT_BRANCH"], exclude: [] },
-    },
-    rules,
+    ],
   };
 }
 
@@ -104,7 +124,7 @@ export function buildTagRuleset(
     name: policy.rulesets.tag,
     target: "tag",
     enforcement: "active",
-    bypass_actors: bypass(appId),
+    bypass_actors: releaseAppBypass(appId),
     conditions: {
       ref_name: { include: ["refs/tags/v*"], exclude: [] },
     },


### PR DESCRIPTION
## Summary

- clarify that public access grants no write permission
- require external contributors to use forks and non-admin maintainers to use pull requests
- allow repository administrators to push directly to `master`
- keep deletion and non-fast-forward protections in a separate ruleset with no bypass
- require pull requests, checks, and CodeQL for non-admin changes
- remove the internal `.agent` reference from public contribution guidance
- require approval before workflows from every external fork can run
- version and test the GitHub approval and ruleset policies

## Validation

- `bun test src/governance`
- `bun run format:check`
- `bun run lint`
- `bun run typecheck`
- `bun run language:check`
- `bun test`
- `bun run build`

## Security

Pull request workflows remain read-only and cannot publish or update `master`. Repository administrators bypass only the contribution ruleset; they cannot bypass deletion or non-fast-forward protection. No secret value is changed or exposed.