### PR TITLE
fix(governance): complete release safeguards

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -44,3 +44,7 @@ updates:
     groups:
       github-actions:
         patterns: ["*"]
+        update-types: [minor, patch]
+    ignore:
+      - dependency-name: "*"
+        update-types: [version-update:semver-major]

--- a/.github/governance/policy.json
+++ b/.github/governance/policy.json
@@ -1,5 +1,5 @@
 {
-  "schemaVersion": 1,
+  "schemaVersion": 2,
   "repository": "Rising-Corporation/create-next-pro-cli",
   "repositorySettings": {
     "defaultBranch": "master",
@@ -23,7 +23,8 @@
   },
   "environment": {
     "name": "ENV",
-    "branch": "master"
+    "branch": "master",
+    "canAdminsBypass": false
   },
   "security": {
     "privateVulnerabilityReporting": true,
@@ -73,6 +74,53 @@
     "validate-template (pnpm)",
     "governance-check"
   ],
+  "dependabot": {
+    "inaccurateAlerts": [
+      {
+        "number": 25,
+        "dependency": "next",
+        "manifestPath": "templates/Projects/default/package.json",
+        "vulnerableRange": ">= 13.0.0, < 15.5.21",
+        "resolvedVersion": "16.2.11"
+      },
+      {
+        "number": 26,
+        "dependency": "next",
+        "manifestPath": "templates/Projects/default/package.json",
+        "vulnerableRange": ">= 13.0.0, < 15.5.21",
+        "resolvedVersion": "16.2.11"
+      },
+      {
+        "number": 27,
+        "dependency": "next",
+        "manifestPath": "templates/Projects/default/package.json",
+        "vulnerableRange": ">= 13.0.0, < 15.5.21",
+        "resolvedVersion": "16.2.11"
+      },
+      {
+        "number": 28,
+        "dependency": "next",
+        "manifestPath": "templates/Projects/default/package.json",
+        "vulnerableRange": ">= 13.0.0, < 15.5.21",
+        "resolvedVersion": "16.2.11"
+      },
+      {
+        "number": 29,
+        "dependency": "next",
+        "manifestPath": "templates/Projects/default/package.json",
+        "vulnerableRange": ">= 13.0.0, < 15.5.21",
+        "resolvedVersion": "16.2.11"
+      },
+      {
+        "number": 30,
+        "dependency": "next",
+        "manifestPath": "templates/Projects/default/package.json",
+        "vulnerableRange": ">= 12.0.0, < 15.5.21",
+        "resolvedVersion": "16.2.11"
+      }
+    ],
+    "maintenancePullRequests": [10, 13]
+  },
   "cleanup": {
     "pullRequests": [9],
     "branches": [

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -135,7 +135,7 @@ jobs:
       - name: Inspect governance drift without mutation
         env:
           GH_TOKEN: ${{ github.token }}
-        run: bun run github:plan -- --json
+        run: bun run github:plan -- --profile ci --json
 
   release-preflight:
     if: github.event_name == 'push' && github.ref == 'refs/heads/master' && github.actor != 'create-next-pro-release[bot]'
@@ -174,14 +174,13 @@ jobs:
     environment:
       name: ENV
     permissions:
-      contents: write
+      contents: read
       id-token: write
     concurrency:
       group: npm-release-master
       cancel-in-progress: false
     steps:
       - name: Mint the dedicated release App token
-        if: vars.RELEASE_APP_ID != ''
         id: release-app
         uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2
         with:
@@ -189,11 +188,19 @@ jobs:
           private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
           owner: Rising-Corporation
           repositories: create-next-pro-cli
+      - name: Verify release App repository scope
+        env:
+          GH_TOKEN: ${{ steps.release-app.outputs.token }}
+        shell: bash
+        run: |
+          repositories=$(gh api installation/repositories)
+          test "$(jq -r .total_count <<< "$repositories")" = 1
+          test "$(jq -r '.repositories[0].full_name' <<< "$repositories")" = "$GITHUB_REPOSITORY"
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
           ref: master
           fetch-depth: 0
-          token: ${{ steps.release-app.outputs.token || github.token }}
+          token: ${{ steps.release-app.outputs.token }}
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
           bun-version: 1.3.14
@@ -209,6 +216,8 @@ jobs:
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
       - name: Resolve release state
         id: release
+        env:
+          GH_TOKEN: ${{ steps.release-app.outputs.token }}
         shell: bash
         run: |
           git fetch --force origin master '+refs/tags/*:refs/tags/*'
@@ -267,7 +276,7 @@ jobs:
           version="${{ steps.release.outputs.version }}"
           existing=$(npm view "create-next-pro-cli@$version" version --json 2>/dev/null | jq -r '. // empty') || true
           if [ "$existing" = "$version" ]; then
-            bun scripts/verify-npm-provenance.ts create-next-pro-cli "$version" "$GITHUB_SHA" "$GITHUB_RUN_ID"
+            bun scripts/verify-npm-provenance.ts create-next-pro-cli "$version" "$GITHUB_SHA" "$GITHUB_RUN_ID" "$(git rev-parse HEAD)"
             echo "create-next-pro-cli@$version is already published by this trusted workflow"
           else
             npm publish "${{ steps.package.outputs.archive }}" --access public
@@ -287,20 +296,36 @@ jobs:
           test "$(git rev-list -n 1 "v$expected")" = "$(git rev-parse HEAD)"
           test "$(git ls-remote origin refs/heads/master | cut -f1)" = "$(git rev-parse HEAD)"
           test "$(git ls-remote origin "refs/tags/v$expected^{}" | cut -f1)" = "$(git rev-parse HEAD)"
-          test "$(npm view "create-next-pro-cli@$expected" gitHead --json | jq -r .)" = "$(git rev-parse HEAD)"
+          git_head=$(npm view "create-next-pro-cli@$expected" gitHead 2>/dev/null || true)
+          if [ -n "$git_head" ]; then
+            test "$git_head" = "$(git rev-parse HEAD)"
+          fi
           if [ "${{ steps.release.outputs.action }}" = release ]; then
             test "$(git rev-parse HEAD^)" = "$GITHUB_SHA"
           fi
-          bun scripts/verify-npm-provenance.ts create-next-pro-cli "$expected" "$GITHUB_SHA" "$GITHUB_RUN_ID"
+          bun scripts/verify-npm-provenance.ts create-next-pro-cli "$expected" "$GITHUB_SHA" "$GITHUB_RUN_ID" "$(git rev-parse HEAD)"
           test "$(npm access get status create-next-pro-cli)" = "create-next-pro-cli: public"
           npm owner ls create-next-pro-cli | grep -Eq '^mrrise[[:space:]]'
+          mkdir -p /tmp/npm-release-verification
+          canonical=$(npm pack "create-next-pro-cli@$expected" --pack-destination /tmp/npm-release-verification --json | jq -r '.[0].filename')
+          canonical="/tmp/npm-release-verification/$canonical"
+          local_digest=$(cut -d ' ' -f1 /tmp/create-next-pro-package.sha256)
+          test "$(sha256sum "$canonical" | cut -d ' ' -f1)" = "$local_digest"
       - name: Download canonical package for GitHub Release recovery
         if: steps.release.outputs.action == 'finalize'
         id: recovery-package
         shell: bash
         run: |
+          version="${{ steps.release.outputs.version }}"
+          test "$(git show "v$version:package.json" | jq -r .version)" = "$version"
+          test "$(git rev-list -n 1 "v$version")" = "$(git rev-parse HEAD)"
+          git_head=$(npm view "create-next-pro-cli@$version" gitHead 2>/dev/null || true)
+          if [ -n "$git_head" ]; then
+            test "$git_head" = "$(git rev-parse HEAD)"
+          fi
+          bun scripts/verify-npm-provenance.ts create-next-pro-cli "$version" "$GITHUB_SHA" "$GITHUB_RUN_ID" "$(git rev-parse HEAD)"
           mkdir -p /tmp/github-release
-          archive=$(npm pack "create-next-pro-cli@${{ steps.release.outputs.version }}" --pack-destination /tmp/github-release --json | jq -r '.[0].filename')
+          archive=$(npm pack "create-next-pro-cli@$version" --pack-destination /tmp/github-release --json | jq -r '.[0].filename')
           archive="/tmp/github-release/$archive"
           test -f "$archive"
           sha256sum "$archive" | tee /tmp/create-next-pro-package.sha256
@@ -308,27 +333,37 @@ jobs:
       - name: Create or reconcile GitHub Release
         if: steps.release.outputs.action == 'release' || steps.release.outputs.action == 'resume' || steps.release.outputs.action == 'finalize'
         env:
-          GH_TOKEN: ${{ steps.release-app.outputs.token || github.token }}
+          GH_TOKEN: ${{ steps.release-app.outputs.token }}
         shell: bash
         run: |
           version="${{ steps.release.outputs.version }}"
           if gh release view "v$version" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
             echo "GitHub Release v$version already exists"
-            exit 0
-          fi
-          if [ "${{ steps.release.outputs.action }}" = finalize ]; then
-            archive="${{ steps.recovery-package.outputs.archive }}"
           else
-            archive="${{ steps.package.outputs.archive }}"
+            if [ "${{ steps.release.outputs.action }}" = finalize ]; then
+              archive="${{ steps.recovery-package.outputs.archive }}"
+            else
+              archive="${{ steps.package.outputs.archive }}"
+            fi
+            gh release create "v$version" \
+              --repo "$GITHUB_REPOSITORY" \
+              --verify-tag \
+              --generate-notes \
+              --title "v$version" \
+              "$archive" \
+              "/tmp/create-next-pro-package.sha256"
           fi
-          gh release create "v$version" \
-            --repo "$GITHUB_REPOSITORY" \
-            --verify-tag \
-            --generate-notes \
-            --title "v$version" \
-            "$archive" \
-            "/tmp/create-next-pro-package.sha256"
-          gh release view "v$version" --repo "$GITHUB_REPOSITORY" --json isDraft,isPrerelease,tagName,url
+          release=$(gh release view "v$version" --repo "$GITHUB_REPOSITORY" --json isDraft,isPrerelease,tagName,url)
+          test "$(jq -r .tagName <<< "$release")" = "v$version"
+          test "$(jq -r .isDraft <<< "$release")" = false
+          test "$(jq -r .isPrerelease <<< "$release")" = false
+          rm -rf /tmp/github-release-verification
+          mkdir -p /tmp/github-release-verification
+          archive_name="create-next-pro-cli-$version.tgz"
+          gh release download "v$version" --repo "$GITHUB_REPOSITORY" --pattern "$archive_name" --dir /tmp/github-release-verification
+          expected_digest=$(cut -d ' ' -f1 /tmp/create-next-pro-package.sha256)
+          test "$(sha256sum "/tmp/github-release-verification/$archive_name" | cut -d ' ' -f1)" = "$expected_digest"
+          printf '%s\n' "$release"
       - name: Release summary
         if: always()
         run: |

--- a/.github/workflows/release-app-smoke.yml
+++ b/.github/workflows/release-app-smoke.yml
@@ -1,0 +1,61 @@
+name: Release App smoke test
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  release-app-smoke:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    environment:
+      name: ENV
+    steps:
+      - name: Mint the dedicated release App token
+        id: release-app
+        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2
+        with:
+          app-id: ${{ vars.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+          owner: Rising-Corporation
+          repositories: create-next-pro-cli
+      - name: Verify release App repository scope
+        env:
+          GH_TOKEN: ${{ steps.release-app.outputs.token }}
+        shell: bash
+        run: |
+          repositories=$(gh api installation/repositories)
+          test "$(jq -r .total_count <<< "$repositories")" = 1
+          test "$(jq -r '.repositories[0].full_name' <<< "$repositories")" = "$GITHUB_REPOSITORY"
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          fetch-depth: 0
+          token: ${{ steps.release-app.outputs.token }}
+      - name: Push temporary branch and protected tag with the App
+        env:
+          BRANCH_NAME: governance/release-app-smoke-${{ github.run_id }}-${{ github.run_attempt }}
+          TAG_NAME: v0.0.0-smoke.${{ github.run_id }}.${{ github.run_attempt }}
+        shell: bash
+        run: |
+          git config user.name "create-next-pro release bot"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git commit --allow-empty -m "chore(ci): verify release app permissions"
+          git tag --annotate "$TAG_NAME" --message "$TAG_NAME"
+          git push origin "HEAD:refs/heads/$BRANCH_NAME"
+          git push origin "refs/tags/$TAG_NAME:refs/tags/$TAG_NAME"
+          test "$(git ls-remote origin "refs/heads/$BRANCH_NAME" | cut -f1)" = "$(git rev-parse HEAD)"
+          test "$(git ls-remote origin "refs/tags/$TAG_NAME^{}" | cut -f1)" = "$(git rev-parse HEAD)"
+      - name: Clean temporary references
+        if: always()
+        env:
+          GH_TOKEN: ${{ steps.release-app.outputs.token }}
+          BRANCH_NAME: governance/release-app-smoke-${{ github.run_id }}-${{ github.run_attempt }}
+          TAG_NAME: v0.0.0-smoke.${{ github.run_id }}.${{ github.run_attempt }}
+        shell: bash
+        run: |
+          gh api --method DELETE "repos/$GITHUB_REPOSITORY/git/refs/heads/$BRANCH_NAME" >/dev/null 2>&1 || true
+          gh api --method DELETE "repos/$GITHUB_REPOSITORY/git/refs/tags/$TAG_NAME" >/dev/null 2>&1 || true
+          test -z "$(git ls-remote origin "refs/heads/$BRANCH_NAME")"
+          test -z "$(git ls-remote origin "refs/tags/$TAG_NAME")"

--- a/scripts/github-governance.ts
+++ b/scripts/github-governance.ts
@@ -10,6 +10,7 @@ import {
   assertGovernancePolicy,
   compareGovernance,
   type GovernancePolicy,
+  type GovernanceProfile,
   type GovernanceResult,
 } from "../src/governance/model";
 import {
@@ -63,6 +64,14 @@ function argumentValue(name: string): string | undefined {
   return index >= 0 ? args[index + 1] : undefined;
 }
 
+function governanceProfile(): GovernanceProfile {
+  const profile = argumentValue("--profile") ?? "admin";
+  if (profile !== "ci" && profile !== "admin") {
+    throw new Error("--profile must be ci or admin");
+  }
+  return profile;
+}
+
 function print(result: GovernanceResult, json: boolean): void {
   if (json) {
     process.stdout.write(`${JSON.stringify(result)}\n`);
@@ -104,7 +113,30 @@ function assertApplyPreconditions(policy: GovernancePolicy): void {
   }
 }
 
-function applyRepositorySettings(policy: GovernancePolicy): void {
+function planProjectsSetting(policy: GovernancePolicy): boolean {
+  const repository = request(`repos/${policy.repository}`) as {
+    has_projects?: boolean;
+  };
+  if (!repository.has_projects) return false;
+  const [owner, name] = policy.repository.split("/");
+  const response = graphql(`query {
+    repository(owner: "${owner}", name: "${name}") {
+      projectsV2(first: 1) { totalCount }
+    }
+  }`) as {
+    data?: { repository?: { projectsV2?: { totalCount?: number } } };
+  };
+  const totalCount = response.data?.repository?.projectsV2?.totalCount;
+  if (typeof totalCount !== "number") {
+    throw new Error("github:apply could not determine the Projects v2 state");
+  }
+  return policy.projectsPolicy === "disable-if-empty" && totalCount === 0;
+}
+
+function applyRepositorySettings(
+  policy: GovernancePolicy,
+  disableProjects: boolean,
+): void {
   mutate("PATCH", `repos/${policy.repository}`, {
     allow_merge_commit: policy.repositorySettings.allowMergeCommit,
     allow_squash_merge: policy.repositorySettings.allowSquashMerge,
@@ -114,6 +146,7 @@ function applyRepositorySettings(policy: GovernancePolicy): void {
     has_issues: policy.repositorySettings.hasIssues,
     has_discussions: policy.repositorySettings.hasDiscussions,
     has_wiki: policy.repositorySettings.hasWiki,
+    ...(disableProjects ? { has_projects: false } : {}),
     squash_merge_commit_title: "PR_TITLE",
     squash_merge_commit_message: "PR_BODY",
   });
@@ -190,7 +223,9 @@ function applyEnvironment(policy: GovernancePolicy): void {
     "PUT",
     `repos/${policy.repository}/environments/${policy.environment.name}`,
     {
-      can_admins_bypass: true,
+      can_admins_bypass: policy.environment.canAdminsBypass,
+      reviewers: [],
+      wait_timer: 0,
       deployment_branch_policy: {
         protected_branches: false,
         custom_branch_policies: true,
@@ -250,6 +285,22 @@ function applyRulesets(policy: GovernancePolicy, stage: RulesetStage): void {
       `${policy.release.appIdVariable} must identify a valid installed release App`,
     );
   }
+  if (appId !== undefined) {
+    const [owner] = policy.repository.split("/");
+    const installations = request(
+      `orgs/${owner}/installations?per_page=100`,
+    ) as {
+      installations?: Array<{ app_id?: number; app_slug?: string }>;
+    };
+    const installation = installations.installations?.find(
+      (candidate) => candidate.app_slug === policy.release.appSlug,
+    );
+    if (!installation || installation.app_id !== appId) {
+      throw new Error(
+        `${policy.release.appIdVariable} does not match the installed ${policy.release.appSlug} GitHub App`,
+      );
+    }
+  }
   upsertRuleset(policy, buildBranchSafetyRuleset(policy));
   if (stage === "branch" || stage === "full") {
     upsertRuleset(policy, buildBranchContributionRuleset(policy, appId));
@@ -308,24 +359,32 @@ function applyCleanup(policy: GovernancePolicy): void {
   }
 }
 
-async function inspect(policy: GovernancePolicy): Promise<GovernanceResult> {
+async function inspect(
+  policy: GovernancePolicy,
+  profile: GovernanceProfile,
+): Promise<GovernanceResult> {
   const transport: GithubTransport = {
     request: async (endpoint) => request(endpoint),
     graphql: async (query) => graphql(query),
   };
   return compareGovernance(
     policy,
-    await collectGithubSnapshot(policy, transport),
+    await collectGithubSnapshot(policy, transport, profile),
   );
 }
 
 async function main(): Promise<void> {
   const command = process.argv[2] ?? "check";
   const json = hasArgument("--json");
+  const profile = governanceProfile();
   const policy = readPolicy();
   if (command === "apply") {
+    if (profile !== "admin") {
+      throw new Error("github:apply requires --profile admin");
+    }
     assertApplyPreconditions(policy);
-    applyRepositorySettings(policy);
+    const disableProjects = planProjectsSetting(policy);
+    applyRepositorySettings(policy, disableProjects);
     applySecurity(policy);
     applyLabels(policy);
     applyEnvironment(policy);
@@ -346,7 +405,7 @@ async function main(): Promise<void> {
     throw new Error(`Unknown governance command: ${command}`);
   }
 
-  const result = await inspect(policy);
+  const result = await inspect(policy, profile);
   print(result, json);
   if (command === "check") {
     process.exitCode =

--- a/scripts/verify-npm-provenance.ts
+++ b/scripts/verify-npm-provenance.ts
@@ -2,10 +2,11 @@ import process from "node:process";
 
 import { verifyNpmProvenance } from "../src/release/provenance";
 
-const [packageName, version, sourceSha, runId] = process.argv.slice(2);
+const [packageName, version, sourceSha, runId, releaseSha] =
+  process.argv.slice(2);
 if (!packageName || !version || !sourceSha || !runId) {
   throw new Error(
-    "usage: verify-npm-provenance <package> <version> <source-sha> <run-id>",
+    "usage: verify-npm-provenance <package> <version> <source-sha> <run-id> [release-sha]",
   );
 }
 
@@ -40,6 +41,7 @@ const result = verifyNpmProvenance(
     workflowPath: ".github/workflows/ci.yml",
     ref: "refs/heads/master",
     runId,
+    releaseSha,
   },
 );
 process.stdout.write(`${JSON.stringify(result)}\n`);

--- a/src/governance/contracts.test.ts
+++ b/src/governance/contracts.test.ts
@@ -98,6 +98,63 @@ describe("public governance contracts", () => {
       ) as unknown,
     );
     expect(policy.repository).toBe("Rising-Corporation/create-next-pro-cli");
+    expect(policy.schemaVersion).toBe(2);
+    expect(policy.environment.canAdminsBypass).toBe(false);
     expect(policy.requiredChecks).toContain("governance-check");
+  });
+
+  test("requires the dedicated release App without a token fallback", async () => {
+    const workflow = await readFile(".github/workflows/ci.yml", "utf8");
+    expect(workflow).toContain("Mint the dedicated release App token");
+    expect(workflow).toContain("token: ${{ steps.release-app.outputs.token }}");
+    expect(workflow).not.toContain("|| github.token");
+    expect(workflow).not.toMatch(
+      /Mint the dedicated release App token\n\s+if:/,
+    );
+    expect(workflow).toContain(
+      'git_head=$(npm view "create-next-pro-cli@$expected" gitHead 2>/dev/null || true)',
+    );
+  });
+
+  test("keeps the release App smoke workflow isolated from master and npm", async () => {
+    const workflow = await readFile(
+      ".github/workflows/release-app-smoke.yml",
+      "utf8",
+    );
+    expect(workflow).toContain("workflow_dispatch:");
+    expect(workflow).toContain("governance/release-app-smoke-");
+    expect(workflow).toContain("v0.0.0-smoke.");
+    expect(workflow).not.toContain("npm publish");
+    expect(workflow).not.toContain("HEAD:master");
+    expect(workflow).toContain("if: always()");
+  });
+
+  test("keeps reviewed Dependabot evidence aligned with the template graph", async () => {
+    const policy = assertGovernancePolicy(
+      JSON.parse(
+        await readFile(".github/governance/policy.json", "utf8"),
+      ) as unknown,
+    );
+    const manifest = JSON.parse(
+      await readFile("templates/Projects/default/package.json", "utf8"),
+    ) as { dependencies?: Record<string, string> };
+    const lockfile = await readFile(
+      "templates/Projects/default/bun.lock",
+      "utf8",
+    );
+    const lockedNextVersions = new Set(
+      [...lockfile.matchAll(/\bnext@(\d+\.\d+\.\d+)/g)].map(
+        (match) => match[1],
+      ),
+    );
+    expect(lockedNextVersions).toEqual(new Set(["16.2.11"]));
+    for (const alert of policy.dependabot.inaccurateAlerts) {
+      expect(alert.dependency).toBe("next");
+      expect(alert.manifestPath).toBe(
+        "templates/Projects/default/package.json",
+      );
+      expect(manifest.dependencies?.next).toBe(alert.resolvedVersion);
+      expect(lockedNextVersions).toContain(alert.resolvedVersion);
+    }
   });
 });

--- a/src/governance/github.test.ts
+++ b/src/governance/github.test.ts
@@ -4,11 +4,11 @@ import { collectGithubSnapshot, type GithubTransport } from "./github";
 import type { GovernancePolicy } from "./model";
 
 const policy = {
-  schemaVersion: 1,
+  schemaVersion: 2,
   repository: "owner/repository",
   repositorySettings: {},
   actions: {},
-  environment: { name: "ENV", branch: "master" },
+  environment: { name: "ENV", branch: "master", canAdminsBypass: false },
   security: {},
   community: { requiredLabels: [], requiredDiscussionCategories: [] },
   release: {
@@ -40,11 +40,22 @@ describe("GitHub governance adapter", () => {
             full_name: "owner/repository",
             default_branch: "master",
             visibility: "public",
+            has_projects: true,
             security_and_analysis: {
               secret_scanning: { status: "enabled" },
               secret_scanning_push_protection: { status: "enabled" },
             },
           };
+        }
+        if (endpoint.endsWith("/environments/ENV")) {
+          return {
+            name: "ENV",
+            can_admins_bypass: false,
+            deployment_branch_policy: { custom_branch_policies: true },
+          };
+        }
+        if (endpoint.endsWith("/deployment-branch-policies?per_page=100")) {
+          return { branch_policies: [{ name: "master" }] };
         }
         if (endpoint.includes("/secrets")) {
           return { secrets: [{ name: "APP_KEY", value: "must-not-be-read" }] };
@@ -61,7 +72,36 @@ describe("GitHub governance adapter", () => {
         if (endpoint.includes("/installations")) {
           return { installations: [{ app_slug: "release-app" }] };
         }
-        if (endpoint.endsWith("/rulesets?per_page=100")) return [];
+        if (endpoint.endsWith("/rulesets?per_page=100")) {
+          return [
+            { id: 1, name: "protect-master" },
+            { id: 2, name: "govern-master-contributions" },
+          ];
+        }
+        if (endpoint.endsWith("/rulesets/1")) {
+          return {
+            name: "protect-master",
+            target: "branch",
+            enforcement: "active",
+            bypass_actors: [],
+            conditions: {
+              ref_name: { include: ["~DEFAULT_BRANCH"], exclude: [] },
+            },
+            rules: [{ type: "deletion" }, { type: "non_fast_forward" }],
+          };
+        }
+        if (endpoint.endsWith("/rulesets/2")) {
+          return {
+            name: "govern-master-contributions",
+            target: "branch",
+            enforcement: "active",
+            bypass_actors: [],
+            conditions: {
+              ref_name: { include: ["~DEFAULT_BRANCH"], exclude: [] },
+            },
+            rules: [],
+          };
+        }
         if (endpoint.endsWith("/labels?per_page=100")) return [];
         return {};
       },
@@ -81,6 +121,9 @@ describe("GitHub governance adapter", () => {
     expect(snapshot.release.secretNames).toEqual(["APP_KEY"]);
     expect(snapshot.release.variableNames).toEqual(["APP_ID"]);
     expect(snapshot.release.releaseEnabled).toBe(true);
+    expect(snapshot.release.appId).toBe(123);
+    expect(snapshot.environment.canAdminsBypass).toBe(false);
+    expect(snapshot.rulesets).toHaveLength(2);
     expect(snapshot.actions.forkPullRequestApprovalPolicy).toBe(
       "all_external_contributors",
     );
@@ -96,6 +139,42 @@ describe("GitHub governance adapter", () => {
     );
   });
 
+  test("does not request administrator-only surfaces in the CI profile", async () => {
+    const requested: string[] = [];
+    const transport: GithubTransport = {
+      async request(endpoint) {
+        requested.push(endpoint);
+        if (endpoint === "repos/owner/repository") {
+          return {
+            full_name: "owner/repository",
+            default_branch: "master",
+            visibility: "public",
+          };
+        }
+        if (endpoint.endsWith("/rulesets?per_page=100")) return [];
+        if (endpoint.endsWith("/labels?per_page=100")) return [];
+        return {};
+      },
+      async graphql() {
+        return {
+          data: { repository: { discussionCategories: { nodes: [] } } },
+        };
+      },
+    };
+    const snapshot = await collectGithubSnapshot(policy, transport, "ci");
+    expect(snapshot.profile).toBe("ci");
+    expect(snapshot.excludedPaths).toContain("release");
+    expect(requested.some((endpoint) => endpoint.includes("/secrets"))).toBe(
+      false,
+    );
+    expect(
+      requested.some((endpoint) => endpoint.includes("/installations")),
+    ).toBe(false);
+    expect(
+      requested.some((endpoint) => endpoint.includes("/environments/")),
+    ).toBe(false);
+  });
+
   test("records inaccessible endpoints instead of guessing", async () => {
     const transport: GithubTransport = {
       async request() {
@@ -108,7 +187,10 @@ describe("GitHub governance adapter", () => {
     const snapshot = await collectGithubSnapshot(policy, transport);
     expect(snapshot.unavailable.length).toBeGreaterThan(0);
     expect(snapshot.unavailable).toContainEqual(
-      expect.objectContaining({ path: "projects", reason: "missing scope" }),
+      expect.objectContaining({
+        path: "community.discussionCategories",
+        reason: "missing scope",
+      }),
     );
   });
 });

--- a/src/governance/github.ts
+++ b/src/governance/github.ts
@@ -1,4 +1,10 @@
-import type { GovernancePolicy, GovernanceSnapshot } from "./model";
+import {
+  CI_EXCLUDED_PATHS,
+  type GovernancePolicy,
+  type GovernanceProfile,
+  type GovernanceSnapshot,
+} from "./model";
+import { canonicalRuleset, type RepositoryRuleset } from "./rulesets";
 
 export type GithubTransport = {
   request(endpoint: string): Promise<unknown>;
@@ -41,122 +47,207 @@ async function optional(
   }
 }
 
+async function collectRulesets(
+  policy: GovernancePolicy,
+  transport: GithubTransport,
+  unavailable: GovernanceSnapshot["unavailable"],
+): Promise<RepositoryRuleset[]> {
+  const listed = array(
+    await optional(unavailable, "rulesets", () =>
+      transport.request(`repos/${policy.repository}/rulesets?per_page=100`),
+    ),
+  );
+  const governedNames = new Set([
+    policy.rulesets.branch,
+    policy.rulesets.contributions,
+    policy.rulesets.tag,
+  ]);
+  const details: RepositoryRuleset[] = [];
+  for (const item of listed) {
+    const summary = record(item);
+    const name = string(summary.name);
+    if (!governedNames.has(name)) continue;
+    const id = summary.id;
+    if (typeof id !== "number") {
+      unavailable.push({
+        path: `rulesets.${name}`,
+        reason: "GitHub returned a ruleset without a numeric identifier",
+      });
+      continue;
+    }
+    const detail = await optional(unavailable, `rulesets.${name}`, () =>
+      transport.request(`repos/${policy.repository}/rulesets/${id}`),
+    );
+    if (detail) details.push(canonicalRuleset(record(detail)));
+  }
+  return details;
+}
+
 export async function collectGithubSnapshot(
   policy: GovernancePolicy,
   transport: GithubTransport,
+  profile: GovernanceProfile = "admin",
 ): Promise<GovernanceSnapshot> {
   const unavailable: GovernanceSnapshot["unavailable"] = [];
+  const admin = profile === "admin";
+  const excludedPaths = admin ? [] : [...CI_EXCLUDED_PATHS];
   const repository = record(
     await optional(unavailable, "repository", () =>
       transport.request(`repos/${policy.repository}`),
     ),
   );
-  const actions = record(
-    await optional(unavailable, "actions.permissions", () =>
-      transport.request(`repos/${policy.repository}/actions/permissions`),
-    ),
-  );
-  const workflow = record(
-    await optional(unavailable, "actions.workflowPermissions", () =>
-      transport.request(
-        `repos/${policy.repository}/actions/permissions/workflow`,
-      ),
-    ),
-  );
-  const forkApproval = record(
-    await optional(unavailable, "actions.forkPullRequestApprovalPolicy", () =>
-      transport.request(
-        `repos/${policy.repository}/actions/permissions/fork-pr-contributor-approval`,
-      ),
-    ),
-  );
-  const environment = record(
-    await optional(unavailable, "environment", () =>
-      transport.request(
-        `repos/${policy.repository}/environments/${policy.environment.name}`,
-      ),
-    ),
-  );
-  const deploymentPolicy = record(environment.deployment_branch_policy);
-  const branchPolicies = boolean(deploymentPolicy.custom_branch_policies)
+  const actions = admin
     ? record(
-        await optional(unavailable, "environment.allowedBranches", () =>
+        await optional(unavailable, "actions.permissions", () =>
+          transport.request(`repos/${policy.repository}/actions/permissions`),
+        ),
+      )
+    : {};
+  const workflow = admin
+    ? record(
+        await optional(unavailable, "actions.workflowPermissions", () =>
           transport.request(
-            `repos/${policy.repository}/environments/${policy.environment.name}/deployment-branch-policies?per_page=100`,
+            `repos/${policy.repository}/actions/permissions/workflow`,
           ),
         ),
       )
     : {};
-  const environmentSecrets = record(
-    await optional(unavailable, "release.secretNames", () =>
-      transport.request(
-        `repos/${policy.repository}/environments/${policy.environment.name}/secrets?per_page=100`,
-      ),
-    ),
-  );
-  const environmentVariables = record(
-    await optional(unavailable, "release.variableNames", () =>
-      transport.request(
-        `repos/${policy.repository}/environments/${policy.environment.name}/variables?per_page=100`,
-      ),
-    ),
-  );
-  const repositoryVariables = record(
-    await optional(unavailable, "release.releaseEnabled", () =>
-      transport.request(
-        `repos/${policy.repository}/actions/variables?per_page=100`,
-      ),
-    ),
-  );
-  const privateReporting = record(
-    await optional(unavailable, "security.privateVulnerabilityReporting", () =>
-      transport.request(
-        `repos/${policy.repository}/private-vulnerability-reporting`,
-      ),
-    ),
-  );
-  const securityFixes = record(
-    await optional(unavailable, "security.automatedSecurityFixes", () =>
-      transport.request(`repos/${policy.repository}/automated-security-fixes`),
-    ),
-  );
-  const codeql = record(
-    await optional(unavailable, "security.codeqlState", () =>
-      transport.request(
-        `repos/${policy.repository}/code-scanning/default-setup`,
-      ),
-    ),
-  );
-  const rulesets = await optional(unavailable, "rulesets", () =>
-    transport.request(`repos/${policy.repository}/rulesets?per_page=100`),
-  );
+  const forkApproval = admin
+    ? record(
+        await optional(
+          unavailable,
+          "actions.forkPullRequestApprovalPolicy",
+          () =>
+            transport.request(
+              `repos/${policy.repository}/actions/permissions/fork-pr-contributor-approval`,
+            ),
+        ),
+      )
+    : {};
+  const environment = admin
+    ? record(
+        await optional(unavailable, "environment", () =>
+          transport.request(
+            `repos/${policy.repository}/environments/${policy.environment.name}`,
+          ),
+        ),
+      )
+    : {};
+  const deploymentPolicy = record(environment.deployment_branch_policy);
+  const branchPolicies =
+    admin && boolean(deploymentPolicy.custom_branch_policies)
+      ? record(
+          await optional(unavailable, "environment.allowedBranches", () =>
+            transport.request(
+              `repos/${policy.repository}/environments/${policy.environment.name}/deployment-branch-policies?per_page=100`,
+            ),
+          ),
+        )
+      : {};
+  const environmentSecrets = admin
+    ? record(
+        await optional(unavailable, "release.secretNames", () =>
+          transport.request(
+            `repos/${policy.repository}/environments/${policy.environment.name}/secrets?per_page=100`,
+          ),
+        ),
+      )
+    : {};
+  const environmentVariables = admin
+    ? record(
+        await optional(unavailable, "release.variableNames", () =>
+          transport.request(
+            `repos/${policy.repository}/environments/${policy.environment.name}/variables?per_page=100`,
+          ),
+        ),
+      )
+    : {};
+  const repositoryVariables = admin
+    ? record(
+        await optional(unavailable, "release.releaseEnabled", () =>
+          transport.request(
+            `repos/${policy.repository}/actions/variables?per_page=100`,
+          ),
+        ),
+      )
+    : {};
+  const privateReporting = admin
+    ? record(
+        await optional(
+          unavailable,
+          "security.privateVulnerabilityReporting",
+          () =>
+            transport.request(
+              `repos/${policy.repository}/private-vulnerability-reporting`,
+            ),
+        ),
+      )
+    : {};
+  const securityFixes = admin
+    ? record(
+        await optional(unavailable, "security.automatedSecurityFixes", () =>
+          transport.request(
+            `repos/${policy.repository}/automated-security-fixes`,
+          ),
+        ),
+      )
+    : {};
+  const codeql = admin
+    ? record(
+        await optional(unavailable, "security.codeqlState", () =>
+          transport.request(
+            `repos/${policy.repository}/code-scanning/default-setup`,
+          ),
+        ),
+      )
+    : {};
+  const rulesets = await collectRulesets(policy, transport, unavailable);
+  const dependabotAlerts = admin
+    ? await optional(unavailable, "dependabot.alerts", () =>
+        transport.request(
+          `repos/${policy.repository}/dependabot/alerts?state=open&per_page=100`,
+        ),
+      )
+    : [];
+  const pullRequests = admin
+    ? await optional(unavailable, "dependabot.maintenancePullRequests", () =>
+        transport.request(
+          `repos/${policy.repository}/pulls?state=open&per_page=100`,
+        ),
+      )
+    : [];
   const labels = await optional(unavailable, "community.labels", () =>
     transport.request(`repos/${policy.repository}/labels?per_page=100`),
   );
-  const [owner] = policy.repository.split("/");
-  const installations = record(
-    await optional(unavailable, "release.installedAppSlugs", () =>
-      transport.request(`orgs/${owner}/installations?per_page=100`),
-    ),
-  );
+  const [owner, repositoryName] = policy.repository.split("/");
+  const installations = admin
+    ? record(
+        await optional(unavailable, "release.installedAppSlugs", () =>
+          transport.request(`orgs/${owner}/installations?per_page=100`),
+        ),
+      )
+    : {};
   const discussions = record(
     await optional(unavailable, "community.discussionCategories", () =>
       transport.graphql(`query {
-        repository(owner: "${owner}", name: "${policy.repository.split("/")[1]}") {
+        repository(owner: "${owner}", name: "${repositoryName}") {
           discussionCategories(first: 100) { nodes { name } }
         }
       }`),
     ),
   );
-  const projects = record(
-    await optional(unavailable, "projects", () =>
-      transport.graphql(`query {
-        repository(owner: "${owner}", name: "${policy.repository.split("/")[1]}") {
-          projectsV2(first: 1) { totalCount }
-        }
-      }`),
-    ),
-  );
+  const projects =
+    admin && repository.has_projects !== false
+      ? record(
+          await optional(unavailable, "projects", () =>
+            transport.graphql(`query {
+            repository(owner: "${owner}", name: "${repositoryName}") {
+              projectsV2(first: 1) { totalCount }
+            }
+          }`),
+          ),
+        )
+      : {};
 
   const security = record(repository.security_and_analysis);
   const allowedBranches = boolean(deploymentPolicy.custom_branch_policies)
@@ -172,11 +263,20 @@ export async function collectGithubSnapshot(
   const repositoryVariableEntries = array(repositoryVariables.variables).map(
     record,
   );
+  const rawAppId = environmentVariableEntries.find(
+    (item) => item.name === policy.release.appIdVariable,
+  )?.value;
+  const appId =
+    typeof rawAppId === "string" && /^\d+$/.test(rawAppId)
+      ? Number(rawAppId)
+      : undefined;
   const projectData = record(
     record(record(projects.data).repository).projectsV2,
   );
 
   return {
+    profile,
+    excludedPaths,
     repository: string(repository.full_name),
     repositorySettings: {
       defaultBranch: string(repository.default_branch),
@@ -217,6 +317,10 @@ export async function collectGithubSnapshot(
     },
     environment: {
       exists: Boolean(environment.name),
+      canAdminsBypass:
+        typeof environment.can_admins_bypass === "boolean"
+          ? environment.can_admins_bypass
+          : undefined,
       allowedBranches,
       secretNames: array(environmentSecrets.secrets).map((item) =>
         string(record(item).name),
@@ -247,19 +351,41 @@ export async function collectGithubSnapshot(
       secretNames: array(environmentSecrets.secrets).map((item) =>
         string(record(item).name),
       ),
+      appId,
       releaseEnabled:
         repositoryVariableEntries.find(
           (item) => item.name === "RELEASE_ENABLED",
         )?.value === "true",
     },
-    rulesets: array(rulesets).map((item) => ({
-      name: string(record(item).name),
-      enforcement: string(record(item).enforcement),
-    })),
-    projects:
-      typeof projectData.totalCount === "number"
-        ? { totalCount: projectData.totalCount }
-        : undefined,
+    rulesets,
+    dependabot: {
+      openAlerts: array(dependabotAlerts).map((item) => {
+        const alert = record(item);
+        const dependency = record(alert.dependency);
+        const vulnerability = record(alert.security_vulnerability);
+        return {
+          number: typeof alert.number === "number" ? alert.number : 0,
+          dependency: string(record(dependency.package).name),
+          manifestPath: string(dependency.manifest_path),
+          vulnerableRange: string(vulnerability.vulnerable_version_range),
+        };
+      }),
+      openPullRequests: array(pullRequests)
+        .map(record)
+        .filter(
+          (pullRequest) => record(pullRequest.user).login === "dependabot[bot]",
+        )
+        .map((pullRequest) =>
+          typeof pullRequest.number === "number" ? pullRequest.number : 0,
+        ),
+    },
+    projects: admin
+      ? repository.has_projects === false
+        ? { enabled: false }
+        : typeof projectData.totalCount === "number"
+          ? { enabled: true, totalCount: projectData.totalCount }
+          : undefined
+      : undefined,
     unavailable,
   };
 }

--- a/src/governance/model.test.ts
+++ b/src/governance/model.test.ts
@@ -2,13 +2,19 @@ import { describe, expect, test } from "vitest";
 
 import {
   assertGovernancePolicy,
+  CI_EXCLUDED_PATHS,
   compareGovernance,
   type GovernancePolicy,
   type GovernanceSnapshot,
 } from "./model";
+import {
+  buildBranchContributionRuleset,
+  buildBranchSafetyRuleset,
+  buildTagRuleset,
+} from "./rulesets";
 
 const policy: GovernancePolicy = {
-  schemaVersion: 1,
+  schemaVersion: 2,
   repository: "owner/repository",
   repositorySettings: {
     defaultBranch: "master",
@@ -30,7 +36,7 @@ const policy: GovernancePolicy = {
     canApprovePullRequestReviews: false,
     forkPullRequestApprovalPolicy: "all_external_contributors",
   },
-  environment: { name: "ENV", branch: "master" },
+  environment: { name: "ENV", branch: "master", canAdminsBypass: false },
   security: {
     privateVulnerabilityReporting: true,
     automatedSecurityFixes: true,
@@ -56,16 +62,31 @@ const policy: GovernancePolicy = {
     allowAdminDirectPush: true,
   },
   requiredChecks: ["validate"],
+  dependabot: {
+    inaccurateAlerts: [
+      {
+        number: 25,
+        dependency: "next",
+        manifestPath: "template/package.json",
+        vulnerableRange: "<15.5.21",
+        resolvedVersion: "16.2.11",
+      },
+    ],
+    maintenancePullRequests: [10],
+  },
   cleanup: { pullRequests: [], branches: [] },
   projectsPolicy: "disable-if-empty",
 };
 
 const snapshot: GovernanceSnapshot = {
+  profile: "admin",
+  excludedPaths: [],
   repository: "owner/repository",
   repositorySettings: { ...policy.repositorySettings },
   actions: { ...policy.actions },
   environment: {
     exists: true,
+    canAdminsBypass: false,
     allowedBranches: ["master"],
     secretNames: ["APP_KEY"],
   },
@@ -75,14 +96,16 @@ const snapshot: GovernanceSnapshot = {
     installedAppSlugs: ["release-app"],
     variableNames: ["APP_ID"],
     secretNames: ["APP_KEY"],
+    appId: 123,
     releaseEnabled: true,
   },
   rulesets: [
-    { name: "protect-master", enforcement: "active" },
-    { name: "govern-master-contributions", enforcement: "active" },
-    { name: "protect-tags", enforcement: "active" },
+    buildBranchSafetyRuleset(policy),
+    buildBranchContributionRuleset(policy, 123),
+    buildTagRuleset(policy, 123),
   ],
-  projects: { totalCount: 1 },
+  dependabot: { openAlerts: [], openPullRequests: [] },
+  projects: { enabled: true, totalCount: 1 },
   unavailable: [],
 };
 
@@ -127,8 +150,100 @@ describe("governance model", () => {
     );
   });
 
+  test("keeps CI exclusions explicit without treating them as drift", () => {
+    expect(CI_EXCLUDED_PATHS).toEqual([
+      "actions",
+      "dependabot",
+      "environment",
+      "projects",
+      "release",
+      "security",
+      "rulesets.releaseAppIdentity",
+    ]);
+    const result = compareGovernance(policy, {
+      ...snapshot,
+      profile: "ci",
+      excludedPaths: [...CI_EXCLUDED_PATHS],
+      actions: { ...snapshot.actions, defaultWorkflowPermissions: "write" },
+      environment: { exists: false, allowedBranches: [], secretNames: [] },
+      release: {
+        installedAppSlugs: [],
+        variableNames: [],
+        secretNames: [],
+      },
+      security: {
+        ...snapshot.security,
+        privateVulnerabilityReporting: false,
+      },
+      projects: undefined,
+    });
+    expect(result.profile).toBe("ci");
+    expect(result.excludedPaths).toEqual([...CI_EXCLUDED_PATHS].sort());
+    expect(result.status).toBe("compliant");
+  });
+
+  test("detects exact ruleset drift, not only a matching name", () => {
+    const contribution = buildBranchContributionRuleset(policy, 123);
+    contribution.rules = contribution.rules.filter(
+      (rule) => rule.type !== "required_status_checks",
+    );
+    const result = compareGovernance(policy, {
+      ...snapshot,
+      rulesets: [
+        buildBranchSafetyRuleset(policy),
+        contribution,
+        buildTagRuleset(policy, 123),
+      ],
+    });
+    expect(result.findings).toContainEqual(
+      expect.objectContaining({
+        path: "rulesets.govern-master-contributions",
+        status: "drift",
+      }),
+    );
+  });
+
+  test("blocks unclassified Dependabot alerts and tracks reviewed drift", () => {
+    const reviewed = compareGovernance(policy, {
+      ...snapshot,
+      dependabot: {
+        openAlerts: [
+          {
+            number: 25,
+            dependency: "next",
+            manifestPath: "template/package.json",
+            vulnerableRange: "<15.5.21",
+          },
+        ],
+        openPullRequests: [10],
+      },
+    });
+    expect(reviewed.status).toBe("drift");
+    expect(reviewed.findings).toContainEqual(
+      expect.objectContaining({
+        path: "dependabot.alerts.25",
+        status: "drift",
+      }),
+    );
+    const unknown = compareGovernance(policy, {
+      ...snapshot,
+      dependabot: {
+        openAlerts: [
+          {
+            number: 99,
+            dependency: "other",
+            manifestPath: "package.json",
+            vulnerableRange: "<1.0.0",
+          },
+        ],
+        openPullRequests: [],
+      },
+    });
+    expect(unknown.status).toBe("blocked");
+  });
+
   test("rejects invalid policy schemas", () => {
-    expect(() => assertGovernancePolicy({ schemaVersion: 2 })).toThrow(
+    expect(() => assertGovernancePolicy({ schemaVersion: 1 })).toThrow(
       "Unsupported governance policy schema",
     );
   });

--- a/src/governance/model.ts
+++ b/src/governance/model.ts
@@ -1,3 +1,13 @@
+import {
+  buildBranchContributionRuleset,
+  buildBranchSafetyRuleset,
+  buildTagRuleset,
+  canonicalRuleset,
+  type RepositoryRuleset,
+} from "./rulesets";
+
+export type GovernanceProfile = "ci" | "admin";
+
 export type GovernanceStatus =
   "compliant" | "drift" | "blocked" | "unsupported";
 
@@ -9,8 +19,18 @@ export type GovernanceFinding = {
   reason?: string;
 };
 
+export const CI_EXCLUDED_PATHS = [
+  "actions",
+  "dependabot",
+  "environment",
+  "projects",
+  "release",
+  "security",
+  "rulesets.releaseAppIdentity",
+] as const;
+
 export type GovernancePolicy = {
-  schemaVersion: 1;
+  schemaVersion: 2;
   repository: string;
   repositorySettings: {
     defaultBranch: string;
@@ -35,7 +55,11 @@ export type GovernancePolicy = {
       | "first_time_contributors_new_to_github"
       | "all_external_contributors";
   };
-  environment: { name: string; branch: string };
+  environment: {
+    name: string;
+    branch: string;
+    canAdminsBypass: boolean;
+  };
   security: {
     privateVulnerabilityReporting: boolean;
     automatedSecurityFixes: boolean;
@@ -61,6 +85,16 @@ export type GovernancePolicy = {
     allowAdminDirectPush: boolean;
   };
   requiredChecks: string[];
+  dependabot: {
+    inaccurateAlerts: Array<{
+      number: number;
+      dependency: string;
+      manifestPath: string;
+      vulnerableRange: string;
+      resolvedVersion: string;
+    }>;
+    maintenancePullRequests: number[];
+  };
   cleanup: {
     pullRequests: number[];
     branches: Array<{ name: string; sha: string }>;
@@ -69,11 +103,14 @@ export type GovernancePolicy = {
 };
 
 export type GovernanceSnapshot = {
+  profile: GovernanceProfile;
+  excludedPaths: string[];
   repository: string;
   repositorySettings: GovernancePolicy["repositorySettings"];
   actions: GovernancePolicy["actions"];
   environment: {
     exists: boolean;
+    canAdminsBypass?: boolean;
     allowedBranches: string[];
     secretNames: string[];
   };
@@ -83,17 +120,29 @@ export type GovernanceSnapshot = {
     installedAppSlugs: string[];
     variableNames: string[];
     secretNames: string[];
+    appId?: number;
     releaseEnabled?: boolean;
   };
-  rulesets: Array<{ name: string; enforcement: string }>;
-  projects?: { totalCount: number };
+  rulesets: RepositoryRuleset[];
+  dependabot: {
+    openAlerts: Array<{
+      number: number;
+      dependency: string;
+      manifestPath: string;
+      vulnerableRange: string;
+    }>;
+    openPullRequests: number[];
+  };
+  projects?: { enabled: boolean; totalCount?: number };
   unavailable: Array<{ path: string; reason: string }>;
 };
 
 export type GovernanceResult = {
-  schemaVersion: 1;
+  schemaVersion: 2;
+  profile: GovernanceProfile;
   repository: string;
   status: GovernanceStatus;
+  excludedPaths: string[];
   findings: GovernanceFinding[];
   summary: {
     compliant: number;
@@ -104,25 +153,41 @@ export type GovernanceResult = {
 };
 
 function stable(value: unknown): unknown {
-  return Array.isArray(value)
-    ? [...value]
-        .map(stable)
-        .sort((left, right) =>
-          JSON.stringify(left).localeCompare(JSON.stringify(right)),
-        )
-    : value;
+  if (Array.isArray(value)) {
+    return [...value]
+      .map(stable)
+      .sort((left, right) =>
+        JSON.stringify(left).localeCompare(JSON.stringify(right)),
+      );
+  }
+  if (value && typeof value === "object") {
+    return Object.fromEntries(
+      Object.entries(value as Record<string, unknown>)
+        .sort(([left], [right]) => left.localeCompare(right))
+        .map(([key, item]) => [key, stable(item)]),
+    );
+  }
+  return value;
 }
 
 function equal(left: unknown, right: unknown): boolean {
   return JSON.stringify(stable(left)) === JSON.stringify(stable(right));
 }
 
+function isExcluded(snapshot: GovernanceSnapshot, path: string): boolean {
+  return snapshot.excludedPaths.some(
+    (excluded) => path === excluded || path.startsWith(`${excluded}.`),
+  );
+}
+
 function exact(
+  snapshot: GovernanceSnapshot,
   findings: GovernanceFinding[],
   path: string,
   expected: unknown,
   actual: unknown,
 ): void {
+  if (isExcluded(snapshot, path)) return;
   findings.push(
     equal(expected, actual)
       ? { path, status: "compliant" }
@@ -131,11 +196,13 @@ function exact(
 }
 
 function containsAll(
+  snapshot: GovernanceSnapshot,
   findings: GovernanceFinding[],
   path: string,
   expected: string[],
   actual: string[],
 ): void {
+  if (isExcluded(snapshot, path)) return;
   const missing = expected.filter((item) => !actual.includes(item));
   findings.push(
     missing.length === 0
@@ -151,12 +218,140 @@ function containsAll(
 }
 
 function resultStatus(findings: GovernanceFinding[]): GovernanceStatus {
-  if (findings.some((finding) => finding.status === "blocked"))
+  if (findings.some((finding) => finding.status === "blocked")) {
     return "blocked";
-  if (findings.some((finding) => finding.status === "drift")) return "drift";
-  if (findings.some((finding) => finding.status === "unsupported"))
+  }
+  if (findings.some((finding) => finding.status === "unsupported")) {
     return "unsupported";
+  }
+  if (findings.some((finding) => finding.status === "drift")) return "drift";
   return "compliant";
+}
+
+function inferredReleaseAppId(
+  snapshot: GovernanceSnapshot,
+): number | undefined {
+  if (snapshot.release.appId !== undefined) return snapshot.release.appId;
+  if (snapshot.profile !== "ci") return undefined;
+  const appIds = new Set(
+    snapshot.rulesets.flatMap((ruleset) =>
+      ruleset.bypass_actors
+        .filter((actor) => actor.actor_type === "Integration")
+        .map((actor) => actor.actor_id),
+    ),
+  );
+  return appIds.size === 1 ? [...appIds][0] : undefined;
+}
+
+function compareRulesets(
+  policy: GovernancePolicy,
+  snapshot: GovernanceSnapshot,
+  findings: GovernanceFinding[],
+): void {
+  const active = snapshot.rulesets.filter(
+    (ruleset) => ruleset.enforcement === "active",
+  );
+  containsAll(
+    snapshot,
+    findings,
+    "rulesets.names",
+    [
+      policy.rulesets.branch,
+      policy.rulesets.contributions,
+      policy.rulesets.tag,
+    ],
+    active.map((ruleset) => ruleset.name),
+  );
+  const byName = new Map(active.map((ruleset) => [ruleset.name, ruleset]));
+  const appId = inferredReleaseAppId(snapshot);
+  const expected: Array<[string, RepositoryRuleset | undefined]> = [
+    [policy.rulesets.branch, buildBranchSafetyRuleset(policy)],
+    [
+      policy.rulesets.contributions,
+      buildBranchContributionRuleset(policy, appId),
+    ],
+    [policy.rulesets.tag, appId ? buildTagRuleset(policy, appId) : undefined],
+  ];
+  for (const [name, ruleset] of expected) {
+    if (!ruleset) continue;
+    exact(
+      snapshot,
+      findings,
+      `rulesets.${name}`,
+      canonicalRuleset(ruleset),
+      byName.has(name) ? canonicalRuleset(byName.get(name)!) : undefined,
+    );
+  }
+}
+
+function compareDependabot(
+  policy: GovernancePolicy,
+  snapshot: GovernanceSnapshot,
+  findings: GovernanceFinding[],
+): void {
+  if (isExcluded(snapshot, "dependabot")) return;
+  const expectedByNumber = new Map(
+    policy.dependabot.inaccurateAlerts.map((alert) => [alert.number, alert]),
+  );
+  for (const alert of snapshot.dependabot.openAlerts) {
+    const expected = expectedByNumber.get(alert.number);
+    if (!expected) {
+      findings.push({
+        path: `dependabot.alerts.${alert.number}`,
+        status: "blocked",
+        actual: alert,
+        reason: "An unclassified Dependabot alert remains open",
+      });
+      continue;
+    }
+    const evidenceMatches =
+      alert.dependency === expected.dependency &&
+      alert.manifestPath === expected.manifestPath &&
+      alert.vulnerableRange === expected.vulnerableRange;
+    findings.push(
+      evidenceMatches
+        ? {
+            path: `dependabot.alerts.${alert.number}`,
+            status: "drift",
+            expected: "dismissed as inaccurate after local graph verification",
+            actual: alert,
+            reason: `The declared ${expected.resolvedVersion} is outside ${expected.vulnerableRange}`,
+          }
+        : {
+            path: `dependabot.alerts.${alert.number}`,
+            status: "blocked",
+            expected,
+            actual: alert,
+            reason: "The live alert no longer matches the reviewed evidence",
+          },
+    );
+  }
+  for (const expected of policy.dependabot.inaccurateAlerts) {
+    if (
+      !snapshot.dependabot.openAlerts.some(
+        (alert) => alert.number === expected.number,
+      )
+    ) {
+      findings.push({
+        path: `dependabot.alerts.${expected.number}`,
+        status: "compliant",
+      });
+    }
+  }
+  const stillOpen = policy.dependabot.maintenancePullRequests.filter((number) =>
+    snapshot.dependabot.openPullRequests.includes(number),
+  );
+  findings.push(
+    stillOpen.length === 0
+      ? { path: "dependabot.maintenancePullRequests", status: "compliant" }
+      : {
+          path: "dependabot.maintenancePullRequests",
+          status: "drift",
+          expected: [],
+          actual: stillOpen,
+          reason: "Superseded maintenance pull requests must be closed",
+        },
+  );
 }
 
 export function compareGovernance(
@@ -164,10 +359,17 @@ export function compareGovernance(
   snapshot: GovernanceSnapshot,
 ): GovernanceResult {
   const findings: GovernanceFinding[] = [];
-  exact(findings, "repository", policy.repository, snapshot.repository);
+  exact(
+    snapshot,
+    findings,
+    "repository",
+    policy.repository,
+    snapshot.repository,
+  );
 
   for (const [key, expected] of Object.entries(policy.repositorySettings)) {
     exact(
+      snapshot,
       findings,
       `repositorySettings.${key}`,
       expected,
@@ -178,6 +380,7 @@ export function compareGovernance(
   }
   for (const [key, expected] of Object.entries(policy.actions)) {
     exact(
+      snapshot,
       findings,
       `actions.${key}`,
       expected,
@@ -185,8 +388,22 @@ export function compareGovernance(
     );
   }
 
-  exact(findings, "environment.exists", true, snapshot.environment.exists);
+  exact(
+    snapshot,
+    findings,
+    "environment.exists",
+    true,
+    snapshot.environment.exists,
+  );
+  exact(
+    snapshot,
+    findings,
+    "environment.canAdminsBypass",
+    policy.environment.canAdminsBypass,
+    snapshot.environment.canAdminsBypass,
+  );
   containsAll(
+    snapshot,
     findings,
     "environment.allowedBranches",
     [policy.environment.branch],
@@ -194,6 +411,7 @@ export function compareGovernance(
   );
   for (const [key, expected] of Object.entries(policy.security)) {
     exact(
+      snapshot,
       findings,
       `security.${key}`,
       expected,
@@ -202,92 +420,98 @@ export function compareGovernance(
   }
 
   containsAll(
+    snapshot,
     findings,
     "community.labels",
     policy.community.requiredLabels,
     snapshot.community.labels,
   );
   containsAll(
+    snapshot,
     findings,
     "community.discussionCategories",
     policy.community.requiredDiscussionCategories,
     snapshot.community.discussionCategories,
   );
   containsAll(
+    snapshot,
     findings,
     "release.installedAppSlugs",
     [policy.release.appSlug],
     snapshot.release.installedAppSlugs,
   );
   containsAll(
+    snapshot,
     findings,
     "release.variableNames",
     [policy.release.appIdVariable],
     snapshot.release.variableNames,
   );
   containsAll(
+    snapshot,
     findings,
     "release.secretNames",
     [policy.release.privateKeySecret],
     snapshot.release.secretNames,
   );
-  const forbidden = policy.release.forbiddenSecrets.filter((secret) =>
-    snapshot.release.secretNames.includes(secret),
-  );
-  findings.push(
-    forbidden.length === 0
-      ? { path: "release.forbiddenSecrets", status: "compliant" }
-      : {
-          path: "release.forbiddenSecrets",
-          status: "drift",
-          expected: [],
-          actual: forbidden,
-          reason: "Long-lived release secrets must be removed",
-        },
-  );
+  if (!isExcluded(snapshot, "release.forbiddenSecrets")) {
+    const forbidden = policy.release.forbiddenSecrets.filter((secret) =>
+      snapshot.release.secretNames.includes(secret),
+    );
+    findings.push(
+      forbidden.length === 0
+        ? { path: "release.forbiddenSecrets", status: "compliant" }
+        : {
+            path: "release.forbiddenSecrets",
+            status: "drift",
+            expected: [],
+            actual: forbidden,
+            reason: "Long-lived release secrets must be removed",
+          },
+    );
+  }
   exact(
+    snapshot,
     findings,
     "release.releaseEnabled",
     policy.release.releaseEnabled,
     snapshot.release.releaseEnabled,
   );
-  containsAll(
-    findings,
-    "rulesets",
-    [
-      policy.rulesets.branch,
-      policy.rulesets.contributions,
-      policy.rulesets.tag,
-    ],
-    snapshot.rulesets
-      .filter((ruleset) => ruleset.enforcement === "active")
-      .map((ruleset) => ruleset.name),
-  );
+  compareRulesets(policy, snapshot, findings);
+  compareDependabot(policy, snapshot, findings);
 
-  if (snapshot.projects) {
-    findings.push({
-      path: "projects",
-      status: snapshot.projects.totalCount === 0 ? "drift" : "compliant",
-      expected:
-        snapshot.projects.totalCount === 0
-          ? "disabled after verification"
-          : "preserved",
-      actual: snapshot.projects,
-    });
-  } else if (!snapshot.unavailable.some((item) => item.path === "projects")) {
-    findings.push({
-      path: "projects",
-      status: "unsupported",
-      reason: "Project state requires the read:project scope",
-    });
+  if (!isExcluded(snapshot, "projects")) {
+    if (snapshot.projects) {
+      const compliant =
+        !snapshot.projects.enabled ||
+        (snapshot.projects.totalCount !== undefined &&
+          snapshot.projects.totalCount > 0);
+      findings.push({
+        path: "projects",
+        status: compliant ? "compliant" : "drift",
+        expected:
+          snapshot.projects.enabled && snapshot.projects.totalCount === 0
+            ? "disabled after verification"
+            : "preserved",
+        actual: snapshot.projects,
+      });
+    } else if (!snapshot.unavailable.some((item) => item.path === "projects")) {
+      findings.push({
+        path: "projects",
+        status: "unsupported",
+        reason: "Project state requires the read:project scope",
+      });
+    }
   }
 
   findings.push(
-    ...snapshot.unavailable.map(({ path, reason }) => ({
-      path,
-      status: "unsupported" as const,
-      reason,
-    })),
+    ...snapshot.unavailable
+      .filter(({ path }) => !isExcluded(snapshot, path))
+      .map(({ path, reason }) => ({
+        path,
+        status: "unsupported" as const,
+        reason,
+      })),
   );
 
   const summary = {
@@ -299,9 +523,11 @@ export function compareGovernance(
       .length,
   };
   return {
-    schemaVersion: 1,
+    schemaVersion: 2,
+    profile: snapshot.profile,
     repository: policy.repository,
     status: resultStatus(findings),
+    excludedPaths: [...snapshot.excludedPaths].sort(),
     findings: findings.sort((left, right) =>
       left.path.localeCompare(right.path),
     ),
@@ -310,12 +536,14 @@ export function compareGovernance(
 }
 
 export function assertGovernancePolicy(value: unknown): GovernancePolicy {
-  if (!value || typeof value !== "object")
+  if (!value || typeof value !== "object") {
     throw new Error("Governance policy must be an object");
+  }
   const candidate = value as Partial<GovernancePolicy>;
   if (
-    candidate.schemaVersion !== 1 ||
-    typeof candidate.repository !== "string"
+    candidate.schemaVersion !== 2 ||
+    typeof candidate.repository !== "string" ||
+    typeof candidate.environment?.canAdminsBypass !== "boolean"
   ) {
     throw new Error("Unsupported governance policy schema");
   }

--- a/src/governance/rulesets.ts
+++ b/src/governance/rulesets.ts
@@ -9,12 +9,12 @@ type RulesetRule = {
 
 export type RepositoryRuleset = {
   name: string;
-  target: "branch" | "tag";
-  enforcement: "active";
+  target: string;
+  enforcement: string;
   bypass_actors: Array<{
     actor_id: number;
-    actor_type: "Integration" | "RepositoryRole";
-    bypass_mode: "always";
+    actor_type: string;
+    bypass_mode: string;
   }>;
   conditions: {
     ref_name: { include: string[]; exclude: string[] };
@@ -22,7 +22,120 @@ export type RepositoryRuleset = {
   rules: RulesetRule[];
 };
 
+type UnknownRuleset = Partial<RepositoryRuleset> & {
+  bypass_actors?: Array<Record<string, unknown>>;
+  conditions?: { ref_name?: { include?: unknown; exclude?: unknown } };
+  rules?: Array<{ type?: unknown; parameters?: Record<string, unknown> }>;
+};
+
 const REPOSITORY_ADMIN_ROLE_ID = 5;
+
+function strings(value: unknown): string[] {
+  return Array.isArray(value)
+    ? value.filter((item): item is string => typeof item === "string").sort()
+    : [];
+}
+
+function canonicalParameters(
+  type: string,
+  parameters: Record<string, unknown> | undefined,
+): Record<string, unknown> | undefined {
+  if (!parameters) return undefined;
+  if (type === "pull_request") {
+    return {
+      dismiss_stale_reviews_on_push:
+        parameters.dismiss_stale_reviews_on_push === true,
+      require_code_owner_review: parameters.require_code_owner_review === true,
+      require_last_push_approval:
+        parameters.require_last_push_approval === true,
+      required_approving_review_count:
+        typeof parameters.required_approving_review_count === "number"
+          ? parameters.required_approving_review_count
+          : 0,
+      required_review_thread_resolution:
+        parameters.required_review_thread_resolution === true,
+    };
+  }
+  if (type === "required_status_checks") {
+    const checks = Array.isArray(parameters.required_status_checks)
+      ? parameters.required_status_checks
+          .map((value) => {
+            const check = value as Record<string, unknown>;
+            return {
+              context: typeof check.context === "string" ? check.context : "",
+              integration_id:
+                typeof check.integration_id === "number"
+                  ? check.integration_id
+                  : null,
+            };
+          })
+          .sort((left, right) => left.context.localeCompare(right.context))
+      : [];
+    return {
+      do_not_enforce_on_create: parameters.do_not_enforce_on_create === true,
+      strict_required_status_checks_policy:
+        parameters.strict_required_status_checks_policy === true,
+      required_status_checks: checks,
+    };
+  }
+  if (type === "code_scanning") {
+    const tools = Array.isArray(parameters.code_scanning_tools)
+      ? parameters.code_scanning_tools
+          .map((value) => {
+            const tool = value as Record<string, unknown>;
+            return {
+              tool: typeof tool.tool === "string" ? tool.tool : "",
+              security_alerts_threshold:
+                typeof tool.security_alerts_threshold === "string"
+                  ? tool.security_alerts_threshold
+                  : "",
+              alerts_threshold:
+                typeof tool.alerts_threshold === "string"
+                  ? tool.alerts_threshold
+                  : "",
+            };
+          })
+          .sort((left, right) => left.tool.localeCompare(right.tool))
+      : [];
+    return { code_scanning_tools: tools };
+  }
+  return parameters;
+}
+
+/** Normalizes only the ruleset fields governed by this repository. */
+export function canonicalRuleset(value: UnknownRuleset): RepositoryRuleset {
+  return {
+    name: typeof value.name === "string" ? value.name : "",
+    target: typeof value.target === "string" ? value.target : "",
+    enforcement: typeof value.enforcement === "string" ? value.enforcement : "",
+    bypass_actors: (value.bypass_actors ?? [])
+      .map((actor) => ({
+        actor_id: typeof actor.actor_id === "number" ? actor.actor_id : 0,
+        actor_type:
+          typeof actor.actor_type === "string" ? actor.actor_type : "",
+        bypass_mode:
+          typeof actor.bypass_mode === "string" ? actor.bypass_mode : "",
+      }))
+      .sort((left, right) =>
+        `${left.actor_type}:${left.actor_id}`.localeCompare(
+          `${right.actor_type}:${right.actor_id}`,
+        ),
+      ),
+    conditions: {
+      ref_name: {
+        include: strings(value.conditions?.ref_name?.include),
+        exclude: strings(value.conditions?.ref_name?.exclude),
+      },
+    },
+    rules: (value.rules ?? [])
+      .map((rule) => {
+        const type = typeof rule.type === "string" ? rule.type : "";
+        const parameters = canonicalParameters(type, rule.parameters);
+        return parameters ? { type, parameters } : { type };
+      })
+      .sort((left, right) => left.type.localeCompare(right.type)),
+  };
+}
 
 function releaseAppBypass(appId: number): RepositoryRuleset["bypass_actors"] {
   if (!Number.isSafeInteger(appId) || appId <= 0) {

--- a/src/release/provenance.test.ts
+++ b/src/release/provenance.test.ts
@@ -15,6 +15,7 @@ const expectation = {
   workflowPath: ".github/workflows/ci.yml",
   ref: "refs/heads/master",
   runId: "12345",
+  releaseSha: "release-sha",
 };
 
 function fixtures(sourceSha = expectation.sourceSha) {
@@ -89,5 +90,30 @@ describe("npm trusted-publishing provenance", () => {
     expect(() =>
       verifyNpmProvenance(metadata, attestations, expectation),
     ).toThrow("source commit mismatch");
+  });
+
+  test("accepts missing npm gitHead metadata", () => {
+    const { metadata, attestations } = fixtures();
+    expect(
+      verifyNpmProvenance(metadata, attestations, expectation),
+    ).not.toHaveProperty("gitHead");
+  });
+
+  test("verifies npm gitHead when the registry provides it", () => {
+    const { metadata, attestations } = fixtures();
+    expect(
+      verifyNpmProvenance(
+        { ...metadata, gitHead: "release-sha" },
+        attestations,
+        expectation,
+      ),
+    ).toHaveProperty("gitHead", "release-sha");
+    expect(() =>
+      verifyNpmProvenance(
+        { ...metadata, gitHead: "different-release" },
+        attestations,
+        expectation,
+      ),
+    ).toThrow("npm gitHead mismatch");
   });
 });

--- a/src/release/provenance.ts
+++ b/src/release/provenance.ts
@@ -10,6 +10,7 @@ export type ProvenanceExpectation = {
   workflowPath: string;
   ref: string;
   runId: string;
+  releaseSha?: string;
 };
 
 export type VerifiedProvenance = {
@@ -19,6 +20,7 @@ export type VerifiedProvenance = {
   workflow: string;
   invocationId: string;
   integrity: string;
+  gitHead?: string;
 };
 
 function object(value: unknown, label: string): JsonObject {
@@ -59,6 +61,13 @@ export function verifyNpmProvenance(
     expected.packageName,
     "package name",
   );
+  const gitHead =
+    typeof metadata.gitHead === "string" && metadata.gitHead.length > 0
+      ? metadata.gitHead
+      : undefined;
+  if (gitHead && expected.releaseSha) {
+    equals(gitHead, expected.releaseSha, "npm gitHead");
+  }
   equals(
     string(metadata.version, "package version"),
     expected.version,
@@ -169,5 +178,6 @@ export function verifyNpmProvenance(
     workflow: `${workflow.path}@${workflow.ref}`,
     invocationId,
     integrity,
+    ...(gitHead ? { gitHead } : {}),
   };
 }


### PR DESCRIPTION
## Summary

- migrate the governance policy and audit output to schema v2 with explicit CI/admin profiles
- compare complete canonical rulesets and classify reviewed Dependabot drift
- require the dedicated release GitHub App, remove token fallbacks, and add a non-publishing smoke workflow
- make npm `gitHead` optional while preserving provenance, lineage, and tarball digest checks
- keep `RELEASE_ENABLED=false` throughout this guard deployment

## Validation

- `bun run format:check`
- `bun run lint`
- `bun run typecheck`
- `bun run language:check`
- `bun test` (171 passed)
- `bun run build`
- `bun run audit`
- package pack/inspection and Bun/Node/launcher smoke tests
- isolated Bun/npm/pnpm Next.js dependency graphs (`16.2.11` only)

## Release safety

This PR cannot publish while the repository variable `RELEASE_ENABLED` remains `false`. The GitHub App credentials and final rulesets will be configured only after this PR is green and merged.